### PR TITLE
add instructions for running against minishift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 Bare Metal Operator
 ===================
+
+## Setup with minishift
+
+1. Install and launch minishift
+
+   https://docs.okd.io/latest/minishift/getting-started/index.html
+
+2. Ensure you're logged in to the correct context and login as a normal user called developer.
+
+    ```
+    oc config use-context minishift
+    oc login
+    Username: developer
+    ```
+
+3. Create a project to host the operator
+
+    ```
+    oc new-project bmo-project
+    ```
+
+4. Install operator-sdk
+
+    ```
+    go get github.com/metalkube/baremetal-operator
+    cd ~/go/src/github.com/metalkube/baremetal-operator
+    oc --as system:admin apply -f deploy/service_account.yaml
+    oc --as system:admin apply -f deploy/role.yaml
+    oc --as system:admin apply -f deploy/role_binding.yaml
+    oc --as system:admin apply -f deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml
+    ```
+
+5. Launch the operator locally
+
+    ```
+    export OPERATOR_NAME=baremetal-operator
+    operator-sdk up local --namespace=bmo-project
+    ```
+
+6. Create the CR
+
+    ```
+    oc apply -f deploy/crds/metalkube_v1alpha1_baremetalhost_cr.yaml
+    ```

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -2,9 +2,12 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: baremetal-operator
+  namespace: bmo-project
 subjects:
 - kind: ServiceAccount
   name: baremetal-operator
+- kind: User
+  name: developer
 roleRef:
   kind: Role
   name: baremetal-operator


### PR DESCRIPTION
Update the README with instructions for setting up the controller in a
dev environment using minishift.

Update the role binding YAML file to allow a developer to run the
controller from outside the cluster. We will likely want to do
something different when we get to really packaging this for
deployment.

Signed-off-by: Doug Hellmann <doug@doughellmann.com>