### PR TITLE
add a method to host to retrieve the operational status

### DIFF
--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -167,15 +167,34 @@ func (host *BareMetalHost) SetLabel(name, value string) bool {
 	return false
 }
 
+// getLabel returns the value associated with the given label. If
+// there is no value, an empty string is returned.
+func (host *BareMetalHost) getLabel(name string) string {
+	if host.Labels == nil {
+		return ""
+	}
+	return host.Labels[name]
+}
+
 // SetOperationalStatus updates the OperationalStatusLabel and returns
 // true when a change is made or false when no change is made.
 func (host *BareMetalHost) SetOperationalStatus(status string) bool {
 	return host.SetLabel(OperationalStatusLabel, status)
 }
 
-// GetCredentialsKey returns a NamespacedName suitable for loading the
+// OperationalStatus returns the value associated with the
+// OperationalStatusLabel
+func (host *BareMetalHost) OperationalStatus() string {
+	status := host.getLabel(OperationalStatusLabel)
+	if status == "" {
+		return "unknown"
+	}
+	return status
+}
+
+// CredentialsKey returns a NamespacedName suitable for loading the
 // Secret containing the credentials associated with the host.
-func (host *BareMetalHost) GetCredentialsKey() types.NamespacedName {
+func (host *BareMetalHost) CredentialsKey() types.NamespacedName {
 	return types.NamespacedName{
 		Name:      host.Spec.BMC.CredentialsName,
 		Namespace: host.ObjectMeta.Namespace,

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -154,9 +154,9 @@ func (host *BareMetalHost) SetErrorMessage(message string) bool {
 	return false
 }
 
-// SetLabel updates the given label when necessary and returns true
+// setLabel updates the given label when necessary and returns true
 // when a change is made or false when no change is made.
-func (host *BareMetalHost) SetLabel(name, value string) bool {
+func (host *BareMetalHost) setLabel(name, value string) bool {
 	if host.Labels == nil {
 		host.Labels = make(map[string]string)
 	}
@@ -176,10 +176,16 @@ func (host *BareMetalHost) getLabel(name string) string {
 	return host.Labels[name]
 }
 
+// SetHardwareProfile updates the HardwareProfileLabel and returns
+// true when a change is made or false when no change is made.
+func (host *BareMetalHost) SetHardwareProfile(name string) bool {
+	return host.setLabel(HardwareProfileLabel, name)
+}
+
 // SetOperationalStatus updates the OperationalStatusLabel and returns
 // true when a change is made or false when no change is made.
 func (host *BareMetalHost) SetOperationalStatus(status string) bool {
-	return host.SetLabel(OperationalStatusLabel, status)
+	return host.setLabel(OperationalStatusLabel, status)
 }
 
 // OperationalStatus returns the value associated with the

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -239,7 +239,7 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (reconcile
 	// FIXME(dhellmann): This should pull data from Ironic and compare
 	// it against known profiles.
 	hardwareProfile := "unknown"
-	if host.SetLabel(metalkubev1alpha1.HardwareProfileLabel, hardwareProfile) {
+	if host.SetHardwareProfile(hardwareProfile) {
 		reqLogger.Info("updating hardware profile", "profile", hardwareProfile)
 		if err := r.client.Update(context.TODO(), host); err != nil {
 			reqLogger.Error(err, "failed to update hardware profile")

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -169,7 +169,7 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (reconcile
 		err := r.setErrorCondition(request, host, bmc.MissingCredentialsMsg)
 		return reconcile.Result{}, err
 	}
-	secretKey := host.GetCredentialsKey()
+	secretKey := host.CredentialsKey()
 	bmcCredsSecret := &v1.Secret{}
 	err = r.client.Get(context.TODO(), secretKey, bmcCredsSecret)
 	if err != nil {


### PR DESCRIPTION
Instead of expecting users of the BareMetalHost to understand how to
fetch the status from the label, add a method.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>