### PR TITLE
adds Machine reference to spec

### DIFF
--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -64,6 +64,9 @@ type BareMetalHostSpec struct {
 
 	// Should the server be online?
 	Online bool `json:"online"`
+
+	// MachineRef is a reference to the machine.openshift.io/Machine
+	MachineRef *corev1.ObjectReference `json:"machineRef,omitempty"`
 }
 
 // FIXME(dhellmann): We probably want some other module to own these

--- a/pkg/apis/metalkube/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/metalkube/v1alpha1/zz_generated.deepcopy.go
@@ -113,6 +113,11 @@ func (in *BareMetalHostSpec) DeepCopyInto(out *BareMetalHostSpec) {
 		}
 	}
 	out.BMC = in.BMC
+	if in.MachineRef != nil {
+		in, out := &in.MachineRef, &out.MachineRef
+		*out = new(v1.ObjectReference)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
When specified, the MachineRef will indicate that a host should be provisioned
and added to the cluster as a Node by way of the specified Machine.