### PR TITLE
fix the command in the deployment instructions

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,7 +20,7 @@ spec:
           - containerPort: 60000
             name: metrics
           command:
-          - baremetal-operator
+          - /baremetal-operator
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
The Dockerfile installs the operator to / and without the explicit
prefix in the command in the deployment settings the executable can't
be found and the pod fails to launch.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>