### PR TITLE
mention operator-sdk in setup instructions

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,6 +1,12 @@
 Setup Development Environment
 =============================
 
+## Install the operator-sdk
+
+Follow the instructions in the Quick Start section of
+https://github.com/operator-framework/operator-sdk to check out and
+install the operator-sdk tools.
+
 ## With minishift
 
 1. Install and launch minishift


### PR DESCRIPTION
The build needs the operator-sdk so make sure we mention it.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>