### PR TITLE
rename IP field of BareMetalHost.BMC to Address

### DIFF
--- a/deploy/crds/metalkube_v1alpha1_baremetalhost_cr.yaml
+++ b/deploy/crds/metalkube_v1alpha1_baremetalhost_cr.yaml
@@ -36,5 +36,5 @@ metadata:
 spec:
   online: true
   bmc:
-    ip: 192.168.100.100
+    address: ipmi://192.168.122.1:6233
     credentialsName: bmc1-secret

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ necessary to manage and provision it.
 
 *bmc* -- The connection information for the BMC controller on the host.
 
-*bmc.ip* -- The IP address for communicating with the BMC controller.
+*bmc.address* -- The URL for communicating with the BMC controller.
 
 *bmc.credentials* -- A reference to a Secret containing the connection
 data, at least username and password, for the BMC.
@@ -36,7 +36,7 @@ metadata:
 spec:
   online: true
   bmc:
-    ip: 192.168.100.100
+    address: ipmi://192.168.122.1:6233
     credentials:
       name: bmc1-secret
 ```
@@ -92,7 +92,7 @@ spec:
   bmc:
     credentials:
       name: bmc1-secret
-    ip: 192.168.100.100
+    address: ipmi://192.168.122.1:6233
   online: true
 status:
   errorMessage: ""

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -48,7 +48,11 @@ const (
 // BMCDetails contains the information necessary to communicate with
 // the bare metal controller module on host.
 type BMCDetails struct {
-	IP string `json:"ip"`
+
+	// Address holds the URL for accessing the controller on the
+	// network.
+	Address string `json:"address"`
+
 	// The name of the secret containing the BMC credentials (requires
 	// keys "username" and "password").
 	CredentialsName string `json:"credentialsName"`

--- a/pkg/bmc/credentials.go
+++ b/pkg/bmc/credentials.go
@@ -4,7 +4,7 @@ const (
 	MissingCredentialsMsg string = "Missing BMC connection details: Credentials"
 	MissingUsernameMsg    string = "Missing BMC connection details: 'username' in credentials"
 	MissingPasswordMsg    string = "Missing BMC connection details: 'password' in credentials"
-	MissingIPMsg          string = "Missing BMC connection details: IP"
+	MissingAddressMsg     string = "Missing BMC connection details: Address"
 )
 
 type Credentials struct {

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -170,10 +170,10 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (reconcile
 
 	// If we do not have all of the needed BMC credentials, set our
 	// operational status to indicate missing information.
-	if host.Spec.BMC.IP == "" {
-		reqLogger.Info(bmc.MissingIPMsg)
-		err := r.setErrorCondition(request, host, bmc.MissingIPMsg)
-		// Without the BMC IP there's no more we can do, so we're
+	if host.Spec.BMC.Address == "" {
+		reqLogger.Info(bmc.MissingAddressMsg)
+		err := r.setErrorCondition(request, host, bmc.MissingAddressMsg)
+		// Without the BMC address there's no more we can do, so we're
 		// going to return the emtpy Result anyway, and don't need to
 		// check err.
 		return reconcile.Result{}, errors.Wrap(err, "failed to set error condition")

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -73,7 +73,7 @@ func newHost(name string, spec *metalkubev1alpha1.BareMetalHostSpec) *metalkubev
 func newDefaultHost() *metalkubev1alpha1.BareMetalHost {
 	spec := &metalkubev1alpha1.BareMetalHostSpec{
 		BMC: metalkubev1alpha1.BMCDetails{
-			IP:              "192.168.100.100",
+			Address:         "ipmi://192.168.122.1:6233",
 			CredentialsName: defaultSecretName,
 		},
 	}
@@ -295,21 +295,21 @@ func TestUpdateGoodCredentialsOnBadSecret(t *testing.T) {
 // of the required BMC settings is put into an error state.
 func TestMissingBMCParameters(t *testing.T) {
 
-	noIP := newHost("missing-bmc-ip",
+	noAddress := newHost("missing-bmc-address",
 		&metalkubev1alpha1.BareMetalHostSpec{
 			BMC: metalkubev1alpha1.BMCDetails{
-				IP:              "",
+				Address:         "",
 				CredentialsName: "bmc-creds-valid",
 			},
 		})
-	r := newTestReconciler(noIP)
-	waitForErrorStatus(t, r, noIP)
+	r := newTestReconciler(noAddress)
+	waitForErrorStatus(t, r, noAddress)
 
 	secretNoUser := newSecret("bmc-creds-no-user", "", "Pass")
 	noUsername := newHost("missing-bmc-username",
 		&metalkubev1alpha1.BareMetalHostSpec{
 			BMC: metalkubev1alpha1.BMCDetails{
-				IP:              "192.168.100.100",
+				Address:         "ipmi://192.168.122.1:6233",
 				CredentialsName: "bmc-creds-no-user",
 			},
 		})
@@ -320,7 +320,7 @@ func TestMissingBMCParameters(t *testing.T) {
 	noPassword := newHost("missing-bmc-password",
 		&metalkubev1alpha1.BareMetalHostSpec{
 			BMC: metalkubev1alpha1.BMCDetails{
-				IP:              "192.168.100.100",
+				Address:         "ipmi://192.168.122.1:6233",
 				CredentialsName: "bmc-creds-no-pass",
 			},
 		})
@@ -336,7 +336,7 @@ func TestFixSecret(t *testing.T) {
 	host := newHost("fix-secret",
 		&metalkubev1alpha1.BareMetalHostSpec{
 			BMC: metalkubev1alpha1.BMCDetails{
-				IP:              "192.168.100.100",
+				Address:         "ipmi://192.168.122.1:6233",
 				CredentialsName: "bmc-creds-no-user",
 			},
 		})
@@ -366,7 +366,7 @@ func TestToggleOnline(t *testing.T) {
 	host := newHost("set-offline",
 		&metalkubev1alpha1.BareMetalHostSpec{
 			BMC: metalkubev1alpha1.BMCDetails{
-				IP:              "192.168.100.100",
+				Address:         "ipmi://192.168.122.1:6233",
 				CredentialsName: "bmc-creds-valid",
 			},
 			Online: true,

--- a/test/e2e/baremetal_test.go
+++ b/test/e2e/baremetal_test.go
@@ -207,7 +207,7 @@ func TestManageHardwareDetails(t *testing.T) {
 	host := makeHost(t, ctx, "hardware-profile",
 		&metalkubev1alpha1.BareMetalHostSpec{
 			BMC: metalkubev1alpha1.BMCDetails{
-				IP:              "192.168.100.100",
+				Address:         "ipmi://192.168.122.1:6233",
 				CredentialsName: "bmc-creds-valid",
 			},
 		})


### PR DESCRIPTION
This changes IP to Address with the assumption that it will hold a URL.

fixes #27

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>