### PR TITLE
Add fields to NIC and Storage types

### DIFF
--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -99,8 +99,8 @@ type Storage struct {
 	// The size of the disk in gigabyte
 	SizeGiB int `json:"sizeGiB"`
 
-	// Storage class, e.g. "Storage Class 1"
-	Class string `json:"class"`
+	// Hardware model
+	Model string `json:"model"`
 }
 
 // NIC describes one network interface on the host.

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -90,20 +90,38 @@ type CPU struct {
 
 // Storage describes one storage device (disk, SSD, etc.) on the host.
 type Storage struct {
-	Name      string `json:"name"`
+	// A name for the disk, e.g. "disk 1 (boot)"
+	Name string `json:"name"`
+
+	// Interface
 	Interface string `json:"interface"`
-	SizeGiB   int    `json:"sizeGiB"`
-	Class     string `json:"class"`
+
+	// The size of the disk in gigabyte
+	SizeGiB int `json:"sizeGiB"`
+
+	// Storage class, e.g. "Storage Class 1"
+	Class string `json:"class"`
 }
 
 // NIC describes one network interface on the host.
 type NIC struct {
-	Name      string `json:"name"`
-	Model     string `json:"model"`
-	Network   string `json:"network"`
-	MAC       string `json:"mac"`
-	IP        string `json:"ip"`
-	SpeedGbps int    `json:"speedGbps"`
+	// The name of the NIC, e.g. "nic-1"
+	Name string `json:"name"`
+
+	// The name of the model, e.g. "virt-io"
+	Model string `json:"model"`
+
+	// The name of the network, e.g. "Pod Networking"
+	Network string `json:"network"`
+
+	// The device MAC addr
+	MAC string `json:"mac"`
+
+	// The IP address of the device
+	IP string `json:"ip"`
+
+	// The speed of the device
+	SpeedGbps int `json:"speedGbps"`
 }
 
 // HardwareDetails collects all of the information about hardware

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -90,12 +90,17 @@ type CPU struct {
 
 // Storage describes one storage device (disk, SSD, etc.) on the host.
 type Storage struct {
-	SizeGiB int    `json:"sizeGiB"`
-	Info    string `json:"info"`
+	Name      string `json:"name"`
+	Interface string `json:"interface"`
+	SizeGiB   int    `json:"sizeGiB"`
+	Class     string `json:"class"`
 }
 
 // NIC describes one network interface on the host.
 type NIC struct {
+	Name      string `json:"name"`
+	Model     string `json:"model"`
+	Network   string `json:"network"`
 	MAC       string `json:"mac"`
 	IP        string `json:"ip"`
 	SpeedGbps int    `json:"speedGbps"`


### PR DESCRIPTION
Opening this to start a discussion: are these the right fields?

I was going by the wireframes which are in turn based on the kubevirt CRD.

Once we are happy with the fields, I will also update the defaults.