### PR TITLE
save power status to its own variable

### DIFF
--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -177,7 +177,11 @@ type BareMetalHostStatus struct {
 	// the last credentials we were able to validate as working
 	GoodCredentials CredentialsStatus `json:"goodCredentials"`
 
+	// the last error message reported by the provisioning subsystem
 	ErrorMessage string `json:"errorMessage"`
+
+	// indicator for whether or not the host is powered on
+	PoweredOn bool `json:"poweredOn"`
 }
 
 // ProvisionStatus holds the state information for a single target.

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -156,8 +156,8 @@ func (p *fixtureProvisioner) PowerOn() (dirty bool, err error) {
 		return dirty, errors.Wrap(err, "could not power on host")
 	}
 
-	if p.host.Status.Provisioning.State != "powered on" {
-		p.host.Status.Provisioning.State = "powered on"
+	if !p.host.Status.PoweredOn {
+		p.host.Status.PoweredOn = true
 		return true, nil
 	}
 
@@ -173,8 +173,8 @@ func (p *fixtureProvisioner) PowerOff() (dirty bool, err error) {
 		return dirty, errors.Wrap(err, "could not power off host")
 	}
 
-	if p.host.Status.Provisioning.State != "powered off" {
-		p.host.Status.Provisioning.State = "powered off"
+	if p.host.Status.PoweredOn {
+		p.host.Status.PoweredOn = false
 		return true, nil
 	}
 


### PR DESCRIPTION
Instead of using the provisioning state field, use a separate field.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>