### PR TITLE
add result type for provisioner API responses

### DIFF
--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -38,42 +38,44 @@ func New(host *metalkubev1alpha1.BareMetalHost, bmcCreds bmc.Credentials) (provi
 }
 
 // Register the host with Fixture.
-func (p *fixtureProvisioner) ensureExists() (dirty bool, err error) {
+func (p *fixtureProvisioner) ensureExists() (result provisioner.Result, err error) {
 	if p.host.Status.Provisioning.ID == "" {
 		p.host.Status.Provisioning.ID = "temporary-fake-id"
 		p.log.Info("setting provisioning id",
 			"provisioningID", p.host.Status.Provisioning.ID)
-		dirty = true
+		result.Dirty = true
 	}
-	return dirty, nil
+	return result, nil
 }
 
 // ValidateManagementAccess tests the connection information for the
 // host to verify that the location and credentials work.
-func (p *fixtureProvisioner) ValidateManagementAccess() (dirty bool, err error) {
+func (p *fixtureProvisioner) ValidateManagementAccess() (result provisioner.Result, err error) {
 	p.log.Info("testing management access")
-	if dirty, err := p.ensureExists(); err != nil {
-		return dirty, errors.Wrap(err, "could not validate management access")
+	if result, err := p.ensureExists(); err != nil {
+		return result, errors.Wrap(err, "could not validate management access")
 	}
-	return dirty, nil
+	result.RequeueAfter = time.Second * 5
+	return result, nil
 }
 
 // InspectHardware updates the HardwareDetails field of the host with
 // details of devices discovered on the hardware. It may be called
 // multiple times, and should return true for its dirty flag until the
 // inspection is completed.
-func (p *fixtureProvisioner) InspectHardware() (dirty bool, err error) {
+func (p *fixtureProvisioner) InspectHardware() (result provisioner.Result, err error) {
 	p.log.Info("inspecting hardware", "status", p.host.OperationalStatus())
 
-	if dirty, err = p.ensureExists(); err != nil {
-		return dirty, errors.Wrap(err, "could not inspect hardware")
+	if result, err = p.ensureExists(); err != nil {
+		return result, errors.Wrap(err, "could not inspect hardware")
 	}
 
 	if p.host.OperationalStatus() != metalkubev1alpha1.OperationalStatusInspecting {
 		// The inspection just started.
 		p.log.Info("starting inspection by setting state")
 		p.host.SetOperationalStatus(metalkubev1alpha1.OperationalStatusInspecting)
-		return true, nil
+		result.Dirty = true
+		return result, nil
 	}
 
 	// The inspection is ongoing. We'll need to check the fixture
@@ -110,17 +112,20 @@ func (p *fixtureProvisioner) InspectHardware() (dirty bool, err error) {
 					},
 				},
 			}
-		return true, nil
+		result.Dirty = true
+		return result, nil
 	}
 
-	return false, nil
+	return result, nil
 }
 
 // Deprovision prepares the host to be removed from the cluster. It
 // may be called multiple times, and should return true for its dirty
 // flag until the deprovisioning operation is completed.
-func (p *fixtureProvisioner) Deprovision() (dirty bool, retryDelay time.Duration, err error) {
+func (p *fixtureProvisioner) Deprovision() (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is removed")
+
+	result.RequeueAfter = deprovisionRequeueDelay
 
 	// NOTE(dhellmann): In order to simulate a multi-step process,
 	// modify some of the status data structures. This is likely not
@@ -130,48 +135,52 @@ func (p *fixtureProvisioner) Deprovision() (dirty bool, retryDelay time.Duration
 	if p.host.Status.HardwareDetails != nil {
 		p.log.Info("clearing hardware details")
 		p.host.Status.HardwareDetails = nil
-		return true, deprovisionRequeueDelay, nil
+		result.Dirty = true
+		return result, nil
 	}
 
 	if p.host.Status.Provisioning.ID != "" {
 		p.log.Info("clearing provisioning id")
 		p.host.Status.Provisioning.ID = ""
-		return true, deprovisionRequeueDelay, nil
+		result.Dirty = true
+		return result, nil
 	}
 
-	return false, 0, nil
+	return result, nil
 }
 
 // PowerOn ensures the server is powered on independently of any image
 // provisioning operation.
-func (p *fixtureProvisioner) PowerOn() (dirty bool, err error) {
+func (p *fixtureProvisioner) PowerOn() (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is powered on")
 
-	if dirty, err = p.ensureExists(); err != nil {
-		return dirty, errors.Wrap(err, "could not power on host")
+	if result, err = p.ensureExists(); err != nil {
+		return result, errors.Wrap(err, "could not power on host")
 	}
 
 	if !p.host.Status.PoweredOn {
 		p.host.Status.PoweredOn = true
-		return true, nil
+		result.Dirty = true
+		return result, nil
 	}
 
-	return false, nil
+	return result, nil
 }
 
 // PowerOff ensures the server is powered off independently of any image
 // provisioning operation.
-func (p *fixtureProvisioner) PowerOff() (dirty bool, err error) {
+func (p *fixtureProvisioner) PowerOff() (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is powered off")
 
-	if dirty, err = p.ensureExists(); err != nil {
-		return dirty, errors.Wrap(err, "could not power off host")
+	if result, err = p.ensureExists(); err != nil {
+		return result, errors.Wrap(err, "could not power off host")
 	}
 
 	if p.host.Status.PoweredOn {
 		p.host.Status.PoweredOn = false
-		return true, nil
+		result.Dirty = true
+		return result, nil
 	}
 
-	return false, nil
+	return result, nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -19,24 +19,34 @@ type Factory func(host *metalkubev1alpha1.BareMetalHost, bmcCreds bmc.Credential
 type Provisioner interface {
 	// ValidateManagementAccess tests the connection information for the
 	// host to verify that the location and credentials work.
-	ValidateManagementAccess() (dirty bool, err error)
+	ValidateManagementAccess() (result Result, err error)
 
 	// InspectHardware updates the HardwareDetails field of the host with
 	// details of devices discovered on the hardware. It may be called
 	// multiple times, and should return true for its dirty flag until the
 	// inspection is completed.
-	InspectHardware() (dirty bool, err error)
+	InspectHardware() (result Result, err error)
 
 	// Deprovision prepares the host to be removed from the cluster. It
 	// may be called multiple times, and should return true for its dirty
 	// flag until the deprovisioning operation is completed.
-	Deprovision() (dirty bool, requeueDelay time.Duration, err error)
+	Deprovision() (result Result, err error)
 
 	// PowerOn ensures the server is powered on independently of any image
 	// provisioning operation.
-	PowerOn() (dirty bool, err error)
+	PowerOn() (result Result, err error)
 
 	// PowerOff ensures the server is powered off independently of any image
 	// provisioning operation.
-	PowerOff() (dirty bool, err error)
+	PowerOff() (result Result, err error)
+}
+
+// Result holds the response from a call in the Provsioner API.
+type Result struct {
+	// Dirty indicates whether the host object needs to be saved.
+	Dirty bool
+	// RequeueAfter indicates how long to wait before making the same
+	// Provisioner call again. The request should only be requeued if
+	// Dirty is also true.
+	RequeueAfter time.Duration
 }


### PR DESCRIPTION
Update the Provisioner API so that all of the potentially multi-step
operations return the same Result type with instructions for the
caller about whether to store the host and how long to wait before
retrying the call.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>