### PR TITLE
create AccessDetails interface

### DIFF
--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -11,125 +11,136 @@ func init() {
 }
 
 func TestParseLibvirtURL(t *testing.T) {
-	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
+	T, H, P, err := getTypeHostPort("libvirt://192.168.122.1:6233/")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if acc.Type != "libvirt" {
-		t.Fatalf("unexpected type: %q", acc.Type)
+	if T != "libvirt" {
+		t.Fatalf("unexpected type: %q", T)
 	}
-	if acc.portNum != "6233" {
-		t.Fatalf("unexpected port: %q", acc.portNum)
+	if P != "6233" {
+		t.Fatalf("unexpected port: %q", P)
 	}
-	if acc.hostname != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", acc.hostname)
-	}
-}
-
-func TestParseLibvirtNeedsMAC(t *testing.T) {
-	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
-	if err != nil {
-		t.Fatalf("unexpected parse error: %v", err)
-	}
-	if !acc.NeedsMAC() {
-		t.Fatal("expected to need a MAC")
+	if H != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", H)
 	}
 }
 
 func TestParseIPMIDefaultSchemeAndPort(t *testing.T) {
-	acc, err := NewAccessDetails("192.168.122.1")
+	T, H, P, err := getTypeHostPort("192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if acc.Type != "ipmi" {
-		t.Fatalf("unexpected type: %q", acc.Type)
+	if T != "ipmi" {
+		t.Fatalf("unexpected type: %q", T)
 	}
-	if acc.hostname != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", acc.hostname)
+	if P != "" { // default is set in DriverInfo() method
+		t.Fatalf("unexpected port: %q", P)
 	}
-	if acc.portNum != ipmiDefaultPort {
-		t.Fatalf("unexpected port: %q", acc.portNum)
+	if H != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", H)
 	}
 }
 
 func TestParseIPMIDefaultSchemeAndPortHostname(t *testing.T) {
-	acc, err := NewAccessDetails("my.favoritebmc.com")
+	T, H, P, err := getTypeHostPort("my.favoritebmc.com")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if acc.Type != "ipmi" {
-		t.Fatalf("unexpected type: %q", acc.Type)
+	if T != "ipmi" {
+		t.Fatalf("unexpected type: %q", T)
 	}
-	if acc.hostname != "my.favoritebmc.com" {
-		t.Fatalf("unexpected hostname: %q", acc.hostname)
+	if P != "" { // default is set in DriverInfo() method
+		t.Fatalf("unexpected port: %q", P)
 	}
-	if acc.portNum != ipmiDefaultPort {
-		t.Fatalf("unexpected port: %q", acc.portNum)
+	if H != "my.favoritebmc.com" {
+		t.Fatalf("unexpected hostname: %q", H)
 	}
 }
 
 func TestParseHostPort(t *testing.T) {
-	acc, err := NewAccessDetails("192.168.122.1:6233")
+	T, H, P, err := getTypeHostPort("192.168.122.1:6233")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if acc.Type != "ipmi" {
-		t.Fatalf("unexpected type: %q", acc.Type)
+	if T != "ipmi" {
+		t.Fatalf("unexpected type: %q", T)
 	}
-	if acc.hostname != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", acc.hostname)
+	if H != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", H)
 	}
-	if acc.portNum != "6233" {
-		t.Fatalf("unexpected port: %q", acc.portNum)
+	if P != "6233" {
+		t.Fatalf("unexpected port: %q", P)
 	}
 }
 
 func TestParseHostPortIPv6(t *testing.T) {
-	acc, err := NewAccessDetails("[fe80::fc33:62ff:fe83:8a76]:6233")
+	T, H, P, err := getTypeHostPort("[fe80::fc33:62ff:fe83:8a76]:6233")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if acc.Type != "ipmi" {
-		t.Fatalf("unexpected type: %q", acc.Type)
+	if T != "ipmi" {
+		t.Fatalf("unexpected type: %q", T)
 	}
-	if acc.hostname != "fe80::fc33:62ff:fe83:8a76" {
-		t.Fatalf("unexpected hostname: %q", acc.hostname)
+	if H != "fe80::fc33:62ff:fe83:8a76" {
+		t.Fatalf("unexpected hostname: %q", H)
 	}
-	if acc.portNum != "6233" {
-		t.Fatalf("unexpected port: %q", acc.portNum)
+	if P != "6233" {
+		t.Fatalf("unexpected port: %q", P)
 	}
 }
 
 func TestParseHostNoPortIPv6(t *testing.T) {
 	// They either have to give us a port or a URL scheme with IPv6.
-	_, err := NewAccessDetails("[fe80::fc33:62ff:fe83:8a76]")
+	_, _, _, err := getTypeHostPort("[fe80::fc33:62ff:fe83:8a76]")
 	if err == nil {
 		t.Fatal("expected parse error")
 	}
 }
 
 func TestParseIPMIURL(t *testing.T) {
-	acc, err := NewAccessDetails("ipmi://192.168.122.1:6233")
+	T, H, P, err := getTypeHostPort("ipmi://192.168.122.1:6233")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
-	if acc.Type != "ipmi" {
-		t.Fatalf("unexpected type: %q", acc.Type)
+	if T != "ipmi" {
+		t.Fatalf("unexpected type: %q", T)
 	}
-	if acc.hostname != "192.168.122.1" {
-		t.Fatalf("unexpected hostname: %q", acc.hostname)
+	if H != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", H)
 	}
-	if acc.portNum != "6233" {
-		t.Fatalf("unexpected port: %q", acc.portNum)
+	if P != "6233" {
+		t.Fatalf("unexpected port: %q", P)
 	}
 }
 
-func TestParseIPMINeedsMAC(t *testing.T) {
+func TestIPMINeedsMAC(t *testing.T) {
 	acc, err := NewAccessDetails("ipmi://192.168.122.1:6233")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 	if acc.NeedsMAC() {
 		t.Fatal("expected to not need a MAC")
+	}
+}
+
+func TestIPMIDriverInfoDefaultPort(t *testing.T) {
+	acc, err := NewAccessDetails("ipmi://192.168.122.1")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	di := acc.DriverInfo(Credentials{})
+	if di["ipmi_port"] != ipmiDefaultPort {
+		t.Fatalf("unexpected port: %v", di["ipmi_port"])
+	}
+}
+
+func TestLibvirtNeedsMAC(t *testing.T) {
+	acc, err := NewAccessDetails("libvirt://192.168.122.1:6233/")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if !acc.NeedsMAC() {
+		t.Fatal("expected to need a MAC")
 	}
 }

--- a/pkg/bmc/ipmi.go
+++ b/pkg/bmc/ipmi.go
@@ -1,0 +1,43 @@
+package bmc
+
+type ipmiAccessDetails struct {
+	bmcType  string
+	portNum  string
+	hostname string
+}
+
+const ipmiDefaultPort = "623"
+
+func (a *ipmiAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *ipmiAccessDetails) NeedsMAC() bool {
+	// libvirt-based hosts used for dev and testing require a MAC
+	// address, specified as part of the host, but we don't want the
+	// provisioner to have to know the rules about which drivers
+	// require what so we hide that detail inside this class and just
+	// let the provisioner know that "some" drivers require a MAC and
+	// it should ask.
+	return a.bmcType == "libvirt"
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *ipmiAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	result := map[string]interface{}{
+		"ipmi_port":     a.portNum,
+		"ipmi_username": bmcCreds.Username,
+		"ipmi_password": bmcCreds.Password,
+		"ipmi_address":  a.hostname,
+	}
+	if a.portNum == "" {
+		result["ipmi_port"] = ipmiDefaultPort
+	}
+	return result
+}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -35,7 +35,7 @@ type ironicProvisioner struct {
 	// a shorter path to the provisioning status data structure
 	status *metalkubev1alpha1.ProvisionStatus
 	// access parameters for the BMC
-	bmcAccess *bmc.AccessDetails
+	bmcAccess bmc.AccessDetails
 	// credentials to log in to the BMC
 	bmcCreds bmc.Credentials
 	// a client for talking to ironic
@@ -237,7 +237,7 @@ func (p *ironicProvisioner) ensureExists() (result provisioner.Result, err error
 	// Some BMC types require a MAC address, so ensure we have one
 	// when we need it. If not, place the host in an error state.
 	if p.bmcAccess.NeedsMAC() && p.host.Spec.BootMACAddress == "" {
-		msg := fmt.Sprintf("BMC driver %s requires a BootMACAddress value", p.bmcAccess.Type)
+		msg := fmt.Sprintf("BMC driver %s requires a BootMACAddress value", p.bmcAccess.Type())
 		p.log.Info(msg)
 		updatedMessage := p.host.SetErrorMessage(msg)
 		result.Dirty = result.Dirty || updatedMessage


### PR DESCRIPTION
Rather than having methods with lots of if-then statements, define an
interface so we can have multiple implementations and just select the
right one in NewAccessDetails().

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>