### PR TITLE
update test wait loop to look for delayed requeue

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -124,7 +124,8 @@ func tryReconcile(t *testing.T, r *ReconcileBareMetalHost, host *metalkubev1alph
 			break
 		}
 
-		if !result.Requeue {
+		t.Logf("result: %v", result)
+		if !result.Requeue && result.RequeueAfter == 0 {
 			t.Fatal(fmt.Errorf("Ended reconcile without test condition being true"))
 			break
 		}


### PR DESCRIPTION
Sometimes the result from a step is a request to requeue after a
delay. In those cases, the Requeue flag is not set but the
RequeueAfter value is non-zero.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>