### PR TITLE
command to build worker file from virsh domain

### DIFF
--- a/cmd/make-worker/main.go
+++ b/cmd/make-worker/main.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"text/template"
+)
+
+/* PARTIAL EXAMPLE XML OUTPUT:
+   <interface type='bridge'>
+     <mac address='00:1a:74:74:e5:cb'/>
+     <source bridge='provisioning'/>
+     <target dev='vnet10'/>
+     <model type='virtio'/>
+     <alias name='net0'/>
+     <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+   </interface>
+*/
+
+// MAC is a hardware address for a NIC
+type MAC struct {
+	XMLName xml.Name `xml:"mac"`
+	Address string   `xml:"address,attr"`
+}
+
+// Source is the network to which the interface is attached
+type Source struct {
+	XMLName xml.Name `xml:"source"`
+	Bridge  string   `xml:"bridge,attr"`
+}
+
+// Interface is one NIC
+type Interface struct {
+	XMLName xml.Name `xml:"interface"`
+	MAC     MAC      `xml:"mac"`
+	Source  Source   `xml:"source"`
+}
+
+// Domain is the main tag for the XML document
+type Domain struct {
+	Interfaces []Interface `xml:"devices>interface"`
+}
+
+var templateBody = `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Domain }}-bmc-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: cGFzc3dvcmQ=
+
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: {{ .Domain }}
+spec:
+  online: true
+  bmc:
+    address: libvirt://192.168.122.1:{{ .BMCPort }}/
+    credentialsName: {{ .Domain }}-bmc-secret
+  bootMACAddress: {{ .MAC }}
+`
+
+type TemplateArgs struct {
+	Domain  string
+	MAC     string
+	BMCPort int
+}
+
+/*
+vbmc list -f json -c 'Domain name' -c Port
+[
+  {
+    "Port": 6230,
+    "Domain name": "openshift_master_0"
+  }, ...
+]
+*/
+
+type VBMC struct {
+	Port int    `json:"Port"`
+	Name string `json:"Domain name"`
+}
+
+func main() {
+	var provisionNet = flag.String(
+		"provision-net", "provisioning", "use the MAC on this network")
+	var verbose = flag.Bool("v", false, "turn on verbose output")
+	var desiredMAC string
+
+	flag.Parse()
+
+	virshDomain := flag.Arg(0)
+	if virshDomain == "" {
+		fmt.Fprintf(os.Stderr, "Missing domain argument\n")
+		os.Exit(1)
+	}
+
+	if *verbose {
+		fmt.Printf("net: %s domain: %s\n", *provisionNet, virshDomain)
+	}
+
+	// Figure out the MAC for the VM
+	virshOut, err := exec.Command("sudo", "virsh", "dumpxml", virshDomain).Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr,
+			"ERROR: Could not get details of domain %s: %s\n",
+			virshDomain, err)
+		os.Exit(1)
+	}
+
+	domainResult := Domain{}
+	xml.Unmarshal([]byte(virshOut), &domainResult)
+	if *verbose {
+		fmt.Printf("%v\n", domainResult)
+	}
+
+	for _, iface := range domainResult.Interfaces {
+		if *verbose {
+			fmt.Printf("%v\n", iface)
+		}
+		if iface.Source.Bridge == *provisionNet {
+			desiredMAC = iface.MAC.Address
+		}
+	}
+	if *verbose {
+		fmt.Printf("Using MAC: %s\n", desiredMAC)
+	}
+	if desiredMAC == "" {
+		fmt.Fprintf(os.Stderr, "Could not find MAC for %s on network %s\n",
+			virshDomain, *provisionNet)
+		os.Exit(1)
+	}
+
+	vbmcOut, err := exec.Command(
+		"vbmc", "list", "-f", "json", "-c", "Domain name", "-c", "Port",
+	).Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Could not get details of vbmc: %s\n", err)
+		os.Exit(1)
+	}
+
+	var vbmcResult []VBMC
+	json.Unmarshal([]byte(vbmcOut), &vbmcResult)
+	nameToPort := make(map[string]int)
+	for _, vbmc := range vbmcResult {
+		if *verbose {
+			fmt.Printf("VBMC: %s: %d\n", vbmc.Name, vbmc.Port)
+		}
+		nameToPort[vbmc.Name] = vbmc.Port
+	}
+
+	args := TemplateArgs{
+		Domain:  strings.Replace(virshDomain, "_", "-", -1),
+		MAC:     desiredMAC,
+		BMCPort: nameToPort[virshDomain],
+	}
+	t := template.Must(template.New("yaml_out").Parse(templateBody))
+	err = t.Execute(os.Stdout, args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err)
+	}
+}

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -73,3 +73,39 @@ spec:
     credentialsName: worker-0-bmc-secret
   bootMACAddress: 00:73:49:3a:76:8e
 ```
+
+The `make-worker` utility can be used to generate a YAML file for
+registering a host. It takes as input the name of the `virsh` domain
+and produces as output the basic YAML to register that host properly,
+with the boot MAC address and BMC address filled in.
+
+```
+$ go run cmd/make-worker/main.go openshift_worker_1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-worker-1-bmc-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: cGFzc3dvcmQ=
+
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: openshift-worker-1
+spec:
+  online: true
+  bmc:
+    address: libvirt://192.168.122.1:6234/
+    credentialsName: openshift-worker-1-bmc-secret
+  bootMACAddress: 00:1a:74:74:e5:cf
+```
+
+The output can be passed directly to `oc apply` like this:
+
+```
+$ go run cmd/make-worker/main.go openshift_worker_1 | oc apply -f -
+```


### PR DESCRIPTION
Add a utility to generate the YAML for registering a host by querying
the virsh and vbmc settings.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>