### PR TITLE
add -test-mode command line flag

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -51,6 +51,17 @@ install the operator-sdk tools.
     oc apply -f deploy/crds/metalkube_v1alpha1_baremetalhost_cr.yaml
     ```
 
+## Running without Ironic
+
+In environments where Ironic is not available, and the only real need
+is to be able to have some test data, use the test fixture provisioner
+instead of the real Ironic provisioner by passing `-test-mode` to the
+operator when launching it.
+
+```
+operator-sdk up local --operator-flags "-test-mode"
+```
+
 ## Using libvirt VMs with Ironic
 
 In order to use VMs as hosts, they need to be connected to vbmc_ and


### PR DESCRIPTION
The UX team needs a way to run the operator without the full
provisioning environment. This switch lets them have a provisioner
that does properly set up the host objects, and does not require
ironic.

Signed-off-by: Doug Hellmann <dhellmann@redhat.com>