### PR TITLE
use markdown syntax for links

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -64,11 +64,9 @@ operator-sdk up local --operator-flags "-test-mode"
 
 ## Using libvirt VMs with Ironic
 
-In order to use VMs as hosts, they need to be connected to vbmc_ and
+In order to use VMs as hosts, they need to be connected to [vbmc](https://docs.openstack.org/tripleo-docs/latest/install/environments/virtualbmc.html) and
 the `bootMACAddress` field needs to be set to the MAC address of the
 network interface that will PXE boot.
-
-.. _vbmc: https://docs.openstack.org/tripleo-docs/latest/install/environments/virtualbmc.html
 
 For example:
 


### PR DESCRIPTION
Link to the vbmc docs using markdown syntax instead of restructuredtext.