### PR TITLE
dev mode enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,10 @@ e2e-local:
 .PHONY: dep
 dep:
 	dep ensure
+
+.PHONY: run
+run:
+	OPERATOR_NAME=baremetal-operator \
+		operator-sdk up local \
+		--namespace=openshift-machine-api \
+		--operator-flags="-dev"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,13 +28,14 @@ func printVersion() {
 }
 
 func main() {
+	devLogging := flag.Bool("dev", false, "enable dev logging")
 	flag.Parse()
 
 	// The logger instantiated here can be changed to any logger
 	// implementing the logr.Logger interface. This logger will
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
-	logf.SetLogger(logf.ZapLogger(false))
+	logf.SetLogger(logf.ZapLogger(*devLogging))
 
 	printVersion()
 


### PR DESCRIPTION
Add "make run" target to simplify running the operator locally.

Add a -dev switch to turn on "development mode", which changes the
logging format to something a little easier for a human to parse.