### PR TITLE
stop using labels for status values

### DIFF
--- a/cmd/make-worker/main.go
+++ b/cmd/make-worker/main.go
@@ -100,6 +100,13 @@ vbmc list -f json -c 'Domain name' -c Port
 ]
 */
 
+// VBMC holds the parameters for describing a virtual machine
+// controller
+type VBMC struct {
+	Port int    `json:"Port"`
+	Name string `json:"Domain name"`
+}
+
 func main() {
 	var provisionNet = flag.String(
 		"provision-net", "provisioning", "use the MAC on this network")

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -16,10 +16,6 @@ const (
 	// hosts to block delete operations until the physical host can be
 	// deprovisioned.
 	BareMetalHostFinalizer string = "baremetalhost.metalkube.org"
-
-	// HardwareProfileLabel is the name of the label added to the host
-	// with the discovered hardware profile.
-	HardwareProfileLabel string = "metalkube.org/hardware-profile"
 )
 
 // OperationalStatus represents the state of the host
@@ -172,6 +168,9 @@ type BareMetalHostStatus struct {
 	// +optional
 	LastUpdated *metav1.Time `json:"lastUpdated,omitempty"`
 
+	// The name of the profile matching the hardware details.
+	HardwareProfile string `json:"hardwareProfile"`
+
 	// The hardware discovered to exist on the host.
 	HardwareDetails *HardwareDetails `json:"hardware,omitempty"`
 
@@ -277,8 +276,12 @@ func (host *BareMetalHost) getLabel(name string) string {
 
 // SetHardwareProfile updates the HardwareProfileLabel and returns
 // true when a change is made or false when no change is made.
-func (host *BareMetalHost) SetHardwareProfile(name string) bool {
-	return host.setLabel(HardwareProfileLabel, name)
+func (host *BareMetalHost) SetHardwareProfile(name string) (dirty bool) {
+	if host.Status.HardwareProfile != name {
+		host.Status.HardwareProfile = name
+		dirty = true
+	}
+	return dirty
 }
 
 // SetOperationalStatus updates the OperationalStatusLabel and returns

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -17,27 +17,27 @@ const (
 	// deprovisioned.
 	BareMetalHostFinalizer string = "baremetalhost.metalkube.org"
 
-	// OperationalStatusLabel is the name of the label added to the
-	// host with the operating status.
-	OperationalStatusLabel string = "metalkube.org/operational-status"
-
-	// OperationalStatusInspecting is the status value for the
-	// OperationalStatusLabel when the host is powered on and running
-	// the discovery image to inspect the hardware resources on the
-	// host.
-	OperationalStatusInspecting string = "inspecting"
-
-	// OperationalStatusOnline is the status value for the
-	// OperationalStatusLabel when the host is powered on and running.
-	OperationalStatusOnline string = "online"
-
-	// OperationalStatusOffline is the status value for the
-	// OperationalStatusLabel when the host is powered off.
-	OperationalStatusOffline string = "offline"
-
 	// HardwareProfileLabel is the name of the label added to the host
 	// with the discovered hardware profile.
 	HardwareProfileLabel string = "metalkube.org/hardware-profile"
+)
+
+// OperationalStatus represents the state of the host
+type OperationalStatus string
+
+const (
+	// OperationalStatusOK is the status value for when the host is
+	// configured correctly and not actively being managed.
+	OperationalStatusOK OperationalStatus = "OK"
+
+	// OperationalStatusInspecting is the status value for when the
+	// host is powered on and running the discovery image to inspect
+	// the hardware resources on the host.
+	OperationalStatusInspecting OperationalStatus = "inspecting"
+
+	// OperationalStatusError is the status value for when the host
+	// has any sort of error.
+	OperationalStatusError OperationalStatus = "error"
 )
 
 // BMCDetails contains the information necessary to communicate with
@@ -161,6 +161,9 @@ type BareMetalHostStatus struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code
 	// after modifying this file
 
+	// OperationalStatus holds the status of the host
+	OperationalStatus OperationalStatus `json:"operationalStatus"`
+
 	// MachineRef will point to the corresponding Machine if it exists.
 	// +optional
 	MachineRef *corev1.ObjectReference `json:"machineRef,omitempty"`
@@ -225,17 +228,29 @@ func (host *BareMetalHost) Available() bool {
 // SetErrorMessage updates the ErrorMessage in the host Status struct
 // when necessary and returns true when a change is made or false when
 // no change is made.
-func (host *BareMetalHost) SetErrorMessage(message string) bool {
+func (host *BareMetalHost) SetErrorMessage(message string) (dirty bool) {
+	if host.Status.OperationalStatus != OperationalStatusError {
+		host.Status.OperationalStatus = OperationalStatusError
+		dirty = true
+	}
 	if host.Status.ErrorMessage != message {
 		host.Status.ErrorMessage = message
-		return true
+		dirty = true
 	}
-	return false
+	return dirty
 }
 
 // ClearError removes any existing error message.
-func (host *BareMetalHost) ClearError() bool {
-	return host.SetErrorMessage("")
+func (host *BareMetalHost) ClearError() (dirty bool) {
+	if host.Status.OperationalStatus != OperationalStatusOK {
+		host.Status.OperationalStatus = OperationalStatusOK
+		dirty = true
+	}
+	if host.Status.ErrorMessage != "" {
+		host.Status.ErrorMessage = ""
+		dirty = true
+	}
+	return dirty
 }
 
 // setLabel updates the given label when necessary and returns true
@@ -268,18 +283,18 @@ func (host *BareMetalHost) SetHardwareProfile(name string) bool {
 
 // SetOperationalStatus updates the OperationalStatusLabel and returns
 // true when a change is made or false when no change is made.
-func (host *BareMetalHost) SetOperationalStatus(status string) bool {
-	return host.setLabel(OperationalStatusLabel, status)
+func (host *BareMetalHost) SetOperationalStatus(status OperationalStatus) bool {
+	if host.Status.OperationalStatus != status {
+		host.Status.OperationalStatus = status
+		return true
+	}
+	return false
 }
 
 // OperationalStatus returns the value associated with the
 // OperationalStatusLabel
-func (host *BareMetalHost) OperationalStatus() string {
-	status := host.getLabel(OperationalStatusLabel)
-	if status == "" {
-		return "unknown"
-	}
-	return status
+func (host *BareMetalHost) OperationalStatus() OperationalStatus {
+	return host.Status.OperationalStatus
 }
 
 // HasError returns a boolean indicating whether there is an error

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -245,17 +245,10 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (reconcile
 			return reconcile.Result{}, errors.Wrap(err, "hardware inspection failed")
 		}
 		if provResult.Dirty || dirty {
-			reqLogger.Info("saving host after inspecting hardware")
-			if err := r.client.Update(context.TODO(), host); err != nil {
+			reqLogger.Info("saving hardware details after inspecting hardware")
+			if err := r.saveStatus(host); err != nil {
 				return reconcile.Result{}, errors.Wrap(err,
-					"failed to save host after inspection")
-			}
-			if host.Status.HardwareDetails != nil {
-				reqLogger.Info("saving hardware details")
-				if err := r.saveStatus(host); err != nil {
-					return reconcile.Result{}, errors.Wrap(err,
-						"failed to save hardware details after inspection")
-				}
+					"failed to save hardware details after inspection")
 			}
 			res := reconcile.Result{
 				Requeue:      true,

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -262,7 +262,7 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (reconcile
 	hardwareProfile := "unknown"
 	if host.SetHardwareProfile(hardwareProfile) {
 		reqLogger.Info("updating hardware profile", "profile", hardwareProfile)
-		if err := r.client.Update(context.TODO(), host); err != nil {
+		if err := r.saveStatus(host); err != nil {
 			return reconcile.Result{}, errors.Wrap(err,
 				"failed to save host after updating hardware profile")
 		}

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -370,16 +370,16 @@ func TestFixSecret(t *testing.T) {
 	waitForNoError(t, r, host)
 }
 
-// TestSetHardwareProfileLabel ensures that the host has a label with
+// TestSetHardwareProfile ensures that the host has a label with
 // the hardware profile name.
-func TestSetHardwareProfileLabel(t *testing.T) {
+func TestSetHardwareProfile(t *testing.T) {
 	host := newDefaultHost()
 	r := newTestReconciler(host)
 
 	tryReconcile(t, r, host,
 		func(host *metalkubev1alpha1.BareMetalHost, result reconcile.Result) bool {
-			t.Logf("labels: %v", host.ObjectMeta.Labels)
-			if host.ObjectMeta.Labels[metalkubev1alpha1.HardwareProfileLabel] != "" {
+			t.Logf("profile: %v", host.Status.HardwareProfile)
+			if host.Status.HardwareProfile != "" {
 				return true
 			}
 			return false

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -107,8 +107,8 @@ func tryReconcile(t *testing.T, r *ReconcileBareMetalHost, host *metalkubev1alph
 	for i := 0; ; i++ {
 		logger := log.WithValues("iteration", i)
 		logger.Info("tryReconcile: top of loop")
-		if i >= 50 {
-			t.Fatal(fmt.Errorf("Exceeded 50 iterations"))
+		if i >= 25 {
+			t.Fatal(fmt.Errorf("Exceeded 25 iterations"))
 		}
 
 		result, err := r.Reconcile(request)

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -135,7 +135,7 @@ func tryReconcile(t *testing.T, r *ReconcileBareMetalHost, host *metalkubev1alph
 	}
 }
 
-func waitForStatus(t *testing.T, r *ReconcileBareMetalHost, host *metalkubev1alpha1.BareMetalHost, desiredStatus string) {
+func waitForStatus(t *testing.T, r *ReconcileBareMetalHost, host *metalkubev1alpha1.BareMetalHost, desiredStatus metalkubev1alpha1.OperationalStatus) {
 	tryReconcile(t, r, host,
 		func(host *metalkubev1alpha1.BareMetalHost, result reconcile.Result) bool {
 			state := host.OperationalStatus()
@@ -161,14 +161,6 @@ func waitForNoError(t *testing.T, r *ReconcileBareMetalHost, host *metalkubev1al
 			return !host.HasError()
 		},
 	)
-}
-
-func waitForOfflineStatus(t *testing.T, r *ReconcileBareMetalHost, host *metalkubev1alpha1.BareMetalHost) {
-	waitForStatus(t, r, host, metalkubev1alpha1.OperationalStatusOffline)
-}
-
-func waitForOnlineStatus(t *testing.T, r *ReconcileBareMetalHost, host *metalkubev1alpha1.BareMetalHost) {
-	waitForStatus(t, r, host, metalkubev1alpha1.OperationalStatusOnline)
 }
 
 // TestAddFinalizers ensures that the finalizers for the host are


### PR DESCRIPTION
This PR includes a couple of related changes to clean up the way we handle status values that we were storing in labels but that we want to store in the status fields instead.