### PR TITLE
Restore VBMC struct definition.

### DIFF
--- a/cmd/make-worker/main.go
+++ b/cmd/make-worker/main.go
@@ -100,6 +100,12 @@ vbmc list -f json -c 'Domain name' -c Port
 ]
 */
 
+// VBMC holds info about domain's VBMC Port and Name
+type VBMC struct {
+       Port int    `json:"Port"`
+       Name string `json:"Domain name"`
+}
+
 func main() {
 	var provisionNet = flag.String(
 		"provision-net", "provisioning", "use the MAC on this network")


### PR DESCRIPTION
Without this definition 'make-worker' utility fails:
  go run cmd/make-worker/main.go worker-0
  # command-line-arguments
  cmd/make-worker/main.go:161:19: undefined: VBMC