### PR TITLE
dev-setup: Use minikube instead of minishift.

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -7,24 +7,16 @@ Follow the instructions in the Quick Start section of
 https://github.com/operator-framework/operator-sdk to check out and
 install the operator-sdk tools.
 
-## With minishift
+## With minkube
 
-1. Install and launch minishift
+1. Install and launch minikube
 
-   https://docs.okd.io/latest/minishift/getting-started/index.html
+   https://kubernetes.io/docs/setup/minikube/
 
-2. Ensure you're logged in to the correct context and login as a normal user called developer.
-
-    ```
-    oc config use-context minishift
-    oc login
-    Username: developer
-    ```
-
-3. Create a project to host the operator
+3. Create a namespace to host the operator
 
     ```
-    oc new-project bmo-project
+    kubectl create namespace bmo-project
     ```
 
 4. Install operator-sdk
@@ -32,10 +24,10 @@ install the operator-sdk tools.
     ```
     go get github.com/metalkube/baremetal-operator
     cd ~/go/src/github.com/metalkube/baremetal-operator
-    oc --as system:admin apply -f deploy/service_account.yaml
-    oc --as system:admin apply -f deploy/role.yaml
-    oc --as system:admin apply -f deploy/role_binding.yaml
-    oc --as system:admin apply -f deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml
+    kubectl apply -f deploy/service_account.yaml
+    kubectl apply -f deploy/role.yaml
+    kubectl apply -f deploy/role_binding.yaml
+    kubectl apply -f deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml
     ```
 
 5. Launch the operator locally
@@ -48,7 +40,7 @@ install the operator-sdk tools.
 6. Create the CR
 
     ```
-    oc apply -f deploy/crds/metalkube_v1alpha1_baremetalhost_cr.yaml
+    kubectl apply -f deploy/crds/metalkube_v1alpha1_baremetalhost_cr.yaml
     ```
 
 ## Running without Ironic


### PR DESCRIPTION
In order to make the docs less specific to OpenShift, convert the
instructions based on minishift to use minikube instead.  The
instructions remain very similar.