### PR TITLE
add a "discovered" state for hosts

### DIFF
--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -26,6 +26,11 @@ const (
 	// configured correctly and not actively being managed.
 	OperationalStatusOK OperationalStatus = "OK"
 
+	// OperationalStatusDiscovered is the status value for when the
+	// host is only partially configured, such as when a few values
+	// are loaded from Ironic.
+	OperationalStatusDiscovered OperationalStatus = "discovered"
+
 	// OperationalStatusInspecting is the status value for when the
 	// host is powered on and running the discovery image to inspect
 	// the hardware resources on the host.


### PR DESCRIPTION
When we discover a host from scanning Ironic's database, we will not
have BMC addresses or credentials. That is not an error, it is just an
incompletely registered host, so add a special state so the UI can
detect the special case.