### PR TITLE
let the baremetal operator download the checksum from a URL

### DIFF
--- a/cmd/make-worker/main.go
+++ b/cmd/make-worker/main.go
@@ -5,8 +5,6 @@ import (
 	"encoding/xml"
 	"flag"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"os/exec"
 	"strings"
@@ -176,23 +174,11 @@ func main() {
 		nameToPort[vbmc.Name] = vbmc.Port
 	}
 
-	resp, err := http.Get(instanceImageChecksumURL)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Could not get image checksum: %s\n", err)
-		os.Exit(1)
-	}
-	defer resp.Body.Close()
-	checksum, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: Could not get image checksum: %s\n", err)
-		os.Exit(1)
-	}
-
 	args := TemplateArgs{
 		Domain:         strings.Replace(virshDomain, "_", "-", -1),
 		MAC:            desiredMAC,
 		BMCPort:        nameToPort[virshDomain],
-		Checksum:       strings.TrimSpace(string(checksum)),
+		Checksum:       instanceImageChecksumURL,
 		ImageSourceURL: strings.TrimSpace(instanceImageSource),
 	}
 	t := template.Must(template.New("yaml_out").Parse(templateBody))

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,27 +18,45 @@ data, at least username and password, for the BMC.
 (true) or off (false). Changing this value will trigger a change in
 power state on the physical host.
 
+*machineRef* -- A reference to a Machine to which this host will be
+attached when it is provisioned.
+
+*image.url* -- The URL of an image to deploy to the host.
+
+*image.checksum* -- An md5 checksum or URL to a file with a checksum
+for the image at *image.url*.
+
+*userData* -- A reference to the Secret containing the user data to be
+passed to the host before it boots.
+
 ```
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: bmc1-secret
+  name: openshift-worker-1-bmc-secret
 type: Opaque
 data:
   username: YWRtaW4=
-  password: MWYyZDFlMmU2N2Rm
+  password: cGFzc3dvcmQ=
+
 ---
 apiVersion: metalkube.org/v1alpha1
 kind: BareMetalHost
 metadata:
-  name: example-baremetalhost
+  name: openshift-worker-1
 spec:
   online: true
   bmc:
-    address: ipmi://192.168.122.1:6233
-    credentials:
-      name: bmc1-secret
+    address: libvirt://192.168.122.1:6234/
+    credentialsName: openshift-worker-1-bmc-secret
+  bootMACAddress: 00:11:55:9e:1d:f7
+  userData:
+    namespace: openshift-machine-api
+    name: worker-user-data
+  image:
+    url: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+    checksum: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2.md5sum"
 ```
 
 ### Status Fields

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -438,7 +438,13 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 		if err != nil {
 			return result, errors.Wrap(err, "Could not fetch image checksum")
 		}
-		defer resp.Body.Close()
+		if resp.Close {
+			defer resp.Body.Close()
+		}
+		if resp.StatusCode != 200 {
+			return result, fmt.Errorf("Failed to fetch image checksum from %s: [%d] %s",
+				checksum, resp.StatusCode, resp.Status)
+		}
 		checksumBody, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			return result, errors.Wrap(err, "Could not read image checksum")

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -2,6 +2,9 @@ package ironic
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -386,6 +389,14 @@ func (p *ironicProvisioner) InspectHardware() (result provisioner.Result, err er
 	return result, nil
 }
 
+func checksumIsURL(checksumURL string) (bool, error) {
+	parsedChecksumURL, err := url.Parse(checksumURL)
+	if err != nil {
+		return false, errors.Wrap(err, "Could not parse image checksum")
+	}
+	return parsedChecksumURL.Scheme != "", nil
+}
+
 // Provision writes the image from the host spec to the host. It may
 // be called multiple times, and should return true for its dirty flag
 // until the deprovisioning operation is completed.
@@ -414,6 +425,27 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 
 	result.RequeueAfter = provisionRequeueDelay
 
+	// FIXME(dhellmann): The Stein version of Ironic supports passing
+	// a URL. When we upgrade, we can stop doing this work ourself.
+	checksum := p.host.Spec.Image.Checksum
+	isURL, err := checksumIsURL(checksum)
+	if err != nil {
+		return result, errors.Wrap(err, "Could not understand image checksum")
+	}
+	if isURL {
+		p.log.Info("looking for checksum for image", "URL", checksum)
+		resp, err := http.Get(checksum)
+		if err != nil {
+			return result, errors.Wrap(err, "Could not fetch image checksum")
+		}
+		defer resp.Body.Close()
+		checksumBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return result, errors.Wrap(err, "Could not read image checksum")
+		}
+		checksum = strings.TrimSpace(string(checksumBody))
+	}
+
 	// Ensure the instance_info properties for the host are set to
 	// tell Ironic where to get the image to be provisioned.
 	var op nodes.UpdateOp
@@ -439,7 +471,7 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 				nodes.UpdateOperation{
 					Op:    op,
 					Path:  "/instance_info/image_checksum",
-					Value: p.host.Spec.Image.Checksum,
+					Value: checksum,
 				},
 				// FIXME(dhellmann): We have to provide something for
 				// the disk size until

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -438,9 +438,7 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 		if err != nil {
 			return result, errors.Wrap(err, "Could not fetch image checksum")
 		}
-		if resp.Close {
-			defer resp.Body.Close()
-		}
+		defer resp.Body.Close()
 		if resp.StatusCode != 200 {
 			return result, fmt.Errorf("Failed to fetch image checksum from %s: [%d] %s",
 				checksum, resp.StatusCode, resp.Status)

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -1,0 +1,31 @@
+package ironic
+
+import (
+	"testing"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+func init() {
+	logf.SetLogger(logf.ZapLogger(true))
+}
+
+func TestChecksumIsURLNo(t *testing.T) {
+	isURL, err := checksumIsURL("checksum-goes-here")
+	if isURL {
+		t.Fail()
+	}
+	if err != nil {
+		t.Fail()
+	}
+}
+
+func TestChecksumIsURLYes(t *testing.T) {
+	isURL, err := checksumIsURL("http://checksum-goes-here")
+	if !isURL {
+		t.Fail()
+	}
+	if err != nil {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
The unit tests for the actuator are failing because we require it to
provide a full checksum for the image being provisioned. This will
allow it to just pass us the URL, and have the operator download it to
learn the checksum from there. Eventually we can just pass the URL to
ironic and let it do the download, but we have to upgrade to a newer
ironic for that.