### PR TITLE
Improve and document bmc.address URL support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,12 @@ necessary to manage and provision it.
 
 *bmc* -- The connection information for the BMC controller on the host.
 
-*bmc.address* -- The URL for communicating with the BMC controller.
+*bmc.address* -- The URL for communicating with the BMC controller. When
+communicating over IPMI, this should be a URL of the form
+`ipmi://<host>:<port>` (an unadorned `<host>:<port>` is also accepted).
+Specifying the port is optional; the default port is 623. Dell iDRAC is also
+supported, by using the scheme `idrac://` in place of `http://` in the iDRAC
+URL.
 
 *bmc.credentials* -- A reference to a Secret containing the connection
 data, at least username and password, for the BMC.

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,8 +13,9 @@ necessary to manage and provision it.
 communicating over IPMI, this should be a URL of the form
 `ipmi://<host>:<port>` (an unadorned `<host>:<port>` is also accepted).
 Specifying the port is optional; the default port is 623. Dell iDRAC is also
-supported, by using the scheme `idrac://` in place of `http://` in the iDRAC
-URL.
+supported, by using the scheme `idrac+http://` (or just `idrac://`), or
+`idrac+https://`, in place of `http://` or `https://` (respectively) in the
+iDRAC URL.
 
 *bmc.credentials* -- A reference to a Secret containing the connection
 data, at least username and password, for the BMC.

--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -71,6 +71,13 @@ func getTypeHostPort(address string) (bmcType, host, port, path string, err erro
 	} else {
 		// Successfully parsed the URL
 		bmcType = parsedURL.Scheme
+		if parsedURL.Opaque != "" {
+			parsedURL, err = url.Parse(strings.Replace(address, ":", "://", 1))
+			if err != nil {
+				return "", "", "", "", errors.Wrap(err, "failed to parse BMC address information")
+
+			}
+		}
 		port = parsedURL.Port()
 		host = parsedURL.Hostname()
 		if parsedURL.Scheme == "" {

--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -104,7 +104,7 @@ func NewAccessDetails(address string) (AccessDetails, error) {
 			portNum:  port,
 			hostname: host,
 		}
-	case "idrac":
+	case "idrac", "idrac+http", "idrac+https":
 		addr = &iDracAccessDetails{
 			bmcType:  bmcType,
 			portNum:  port,

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -273,6 +273,28 @@ func TestiDRACDriverInfo(t *testing.T) {
 	}
 }
 
+func TestiDRACDriverInfoHTTP(t *testing.T) {
+	acc, err := NewAccessDetails("idrac+http://192.168.122.1/")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	di := acc.DriverInfo(Credentials{})
+	if di["drac_address"] != "http://192.168.122.1/" {
+		t.Fatalf("unexpected port: %v", di["ipmi_port"])
+	}
+}
+
+func TestiDRACDriverInfoHTTPS(t *testing.T) {
+	acc, err := NewAccessDetails("idrac+https://192.168.122.1/")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	di := acc.DriverInfo(Credentials{})
+	if di["drac_address"] != "https://192.168.122.1/" {
+		t.Fatalf("unexpected port: %v", di["ipmi_port"])
+	}
+}
+
 func TestiDRACDriverInfoPort(t *testing.T) {
 	acc, err := NewAccessDetails("idrac://192.168.122.1:8080/foo")
 	if err != nil {

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -132,6 +132,44 @@ func TestParseIPMIURL(t *testing.T) {
 	}
 }
 
+func TestParseIPMIURLNoSep(t *testing.T) {
+	T, H, P, A, err := getTypeHostPort("ipmi:192.168.122.1")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if T != "ipmi" {
+		t.Fatalf("unexpected type: %q", T)
+	}
+	if H != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", H)
+	}
+	if P != "" {
+		t.Fatalf("unexpected port: %q", P)
+	}
+	if A != "" {
+		t.Fatalf("unexpected path: %q", A)
+	}
+}
+
+func TestParseIPMIURLNoSepPort(t *testing.T) {
+	T, H, P, A, err := getTypeHostPort("ipmi:192.168.122.1:6233")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if T != "ipmi" {
+		t.Fatalf("unexpected type: %q", T)
+	}
+	if H != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", H)
+	}
+	if P != "6233" {
+		t.Fatalf("unexpected port: %q", P)
+	}
+	if A != "" {
+		t.Fatalf("unexpected path: %q", A)
+	}
+}
+
 func TestIPMINeedsMAC(t *testing.T) {
 	acc, err := NewAccessDetails("ipmi://192.168.122.1:6233")
 	if err != nil {

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -42,8 +42,13 @@ func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interfa
 		host = fmt.Sprintf("%s:%s", host, a.portNum)
 	}
 
+	scheme := "http"
+	if strings.HasSuffix(a.bmcType, "https") {
+		scheme = "https"
+	}
+
 	address := url.URL{
-		Scheme: "http",
+		Scheme: scheme,
 		Host:   host,
 		Path:   a.path,
 	}


### PR DESCRIPTION
Support `idrac+https://` and `ipmi:` without the `//`, and document the allowed URL types in the API docs.