### PR TITLE
add active power state monitoring

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -466,3 +466,33 @@ func TestProvision(t *testing.T) {
 		},
 	)
 }
+
+// TestPowerOn verifies that the controller turns the host on when it
+// should.
+func TestPowerOn(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Spec.Online = true
+	r := newTestReconciler(host)
+
+	tryReconcile(t, r, host,
+		func(host *metalkubev1alpha1.BareMetalHost, result reconcile.Result) bool {
+			t.Logf("power status: %v", host.Status.PoweredOn)
+			return host.Status.PoweredOn
+		},
+	)
+}
+
+// TestPowerOff verifies that the controller turns the host on when it
+// should.
+func TestPowerOff(t *testing.T) {
+	host := newDefaultHost(t)
+	host.Spec.Online = false
+	r := newTestReconciler(host)
+
+	tryReconcile(t, r, host,
+		func(host *metalkubev1alpha1.BareMetalHost, result reconcile.Result) bool {
+			t.Logf("power status: %v", host.Status.PoweredOn)
+			return !host.Status.PoweredOn
+		},
+	)
+}

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -133,6 +133,17 @@ func (p *fixtureProvisioner) InspectHardware() (result provisioner.Result, err e
 	return result, nil
 }
 
+// UpdateHardwareState fetches the latest hardware state of the server
+// and updates the HardwareDetails field of the host with details. It
+// is expected to do this in the least expensive way possible, such as
+// reading from a cache, and return dirty only if any state
+// information has changed.
+func (p *fixtureProvisioner) UpdateHardwareState() (result provisioner.Result, err error) {
+	p.log.Info("updating hardware state")
+	result.Dirty = false
+	return result, nil
+}
+
 // Provision writes the image from the host spec to the host. It may
 // be called multiple times, and should return true for its dirty flag
 // until the deprovisioning operation is completed.
@@ -211,6 +222,8 @@ func (p *fixtureProvisioner) PowerOn() (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is powered on")
 
 	if !p.host.Status.PoweredOn {
+		p.publisher("PowerOn", "Host powered on")
+		p.log.Info("changing status")
 		p.host.Status.PoweredOn = true
 		result.Dirty = true
 		return result, nil
@@ -225,6 +238,8 @@ func (p *fixtureProvisioner) PowerOff() (result provisioner.Result, err error) {
 	p.log.Info("ensuring host is powered off")
 
 	if p.host.Status.PoweredOn {
+		p.publisher("PowerOff", "Host powered off")
+		p.log.Info("changing status")
 		p.host.Status.PoweredOn = false
 		result.Dirty = true
 		return result, nil

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -329,13 +329,12 @@ func (p *ironicProvisioner) ValidateManagementAccess() (result provisioner.Resul
 func (p *ironicProvisioner) InspectHardware() (result provisioner.Result, err error) {
 	p.log.Info("inspecting hardware", "status", p.host.OperationalStatus())
 
-	_, err = p.findExistingHost()
+	ironicNode, err := p.findExistingHost()
 	if err != nil {
 		return result, errors.Wrap(err, "failed to find existing host")
 	}
-	if p.host.HasError() {
-		p.log.Info("host has error, skipping hardware inspection")
-		return result, nil
+	if ironicNode == nil {
+		return result, fmt.Errorf("no ironic node for host")
 	}
 
 	if p.host.OperationalStatus() != metalkubev1alpha1.OperationalStatusInspecting {
@@ -415,9 +414,8 @@ func (p *ironicProvisioner) UpdateHardwareState() (result provisioner.Result, er
 	if err != nil {
 		return result, errors.Wrap(err, "failed to find existing host")
 	}
-	if p.host.HasError() {
-		p.log.Info("host has error, skipping hardware state update")
-		return result, nil
+	if ironicNode == nil {
+		return result, fmt.Errorf("no ironic node for host")
 	}
 
 	var discoveredVal bool

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -42,8 +42,10 @@ const (
 	stateProvisioning         = "provisioning"
 	stateProvisioned          = "provisioned"
 	stateDeprovisioning       = "deprovisioning"
-	powerOn                   = "power on"
-	powerOff                  = "power off"
+	// See nodes.Node.PowerState for details
+	powerOn   = "power on"
+	powerOff  = "power off"
+	powerNone = "None"
 )
 
 // Provisioner implements the provisioning.Provisioner interface
@@ -422,10 +424,11 @@ func (p *ironicProvisioner) UpdateHardwareState() (result provisioner.Result, er
 	switch ironicNode.PowerState {
 	case powerOn:
 		discoveredVal = true
-	case "":
-		discoveredVal = false
 	case powerOff:
 		discoveredVal = false
+	case powerNone:
+		p.log.Info("could not determine power state", "value", ironicNode.PowerState)
+		return result, nil
 	default:
 		p.log.Info("unknown power state", "value", ironicNode.PowerState)
 		return result, nil

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -42,6 +42,8 @@ const (
 	stateProvisioning         = "provisioning"
 	stateProvisioned          = "provisioned"
 	stateDeprovisioning       = "deprovisioning"
+	powerOn                   = "power on"
+	powerOff                  = "power off"
 )
 
 // Provisioner implements the provisioning.Provisioner interface
@@ -418,9 +420,11 @@ func (p *ironicProvisioner) UpdateHardwareState() (result provisioner.Result, er
 
 	var discoveredVal bool
 	switch ironicNode.PowerState {
-	case "power on":
+	case powerOn:
 		discoveredVal = true
-	case "power off":
+	case "":
+		discoveredVal = false
+	case powerOff:
 		discoveredVal = false
 	default:
 		p.log.Info("unknown power state", "value", ironicNode.PowerState)
@@ -815,8 +819,8 @@ func (p *ironicProvisioner) PowerOn() (result provisioner.Result, err error) {
 		"current", p.host.Status.PoweredOn,
 		"target", ironicNode.TargetPowerState)
 
-	if ironicNode.PowerState != "power on" {
-		if ironicNode.TargetPowerState == "power on" {
+	if ironicNode.PowerState != powerOn {
+		if ironicNode.TargetPowerState == powerOn {
 			p.log.Info("waiting for power status to change")
 			result.RequeueAfter = powerRequeueDelay
 			return result, nil
@@ -842,8 +846,8 @@ func (p *ironicProvisioner) PowerOff() (result provisioner.Result, err error) {
 		return result, errors.Wrap(err, "failed to find existing host")
 	}
 
-	if ironicNode.PowerState != "power off" {
-		if ironicNode.TargetPowerState == "power off" {
+	if ironicNode.PowerState != powerOff {
+		if ironicNode.TargetPowerState == powerOff {
 			p.log.Info("waiting for power status to change")
 			result.RequeueAfter = powerRequeueDelay
 			return result, nil

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -31,6 +31,13 @@ type Provisioner interface {
 	// inspection is completed.
 	InspectHardware() (result Result, err error)
 
+	// UpdateHardwareState fetches the latest hardware state of the
+	// server and updates the HardwareDetails field of the host with
+	// details. It is expected to do this in the least expensive way
+	// possible, such as reading from a cache, and return dirty only
+	// if any state information has changed.
+	UpdateHardwareState() (result Result, err error)
+
 	// Provision writes the image from the host spec to the host. It
 	// may be called multiple times, and should return true for its
 	// dirty flag until the deprovisioning operation is completed.


### PR DESCRIPTION
Regularly check the power status of the host to ensure it matches the
desired state.