### PR TITLE
Demo provisioner and controller logic cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,10 @@ run:
 		operator-sdk up local \
 		--namespace=$(RUN_NAMESPACE) \
 		--operator-flags="-dev"
+
+.PHONY: demo
+demo:
+	OPERATOR_NAME=baremetal-operator \
+		operator-sdk up local \
+		--namespace=$(RUN_NAMESPACE) \
+		--operator-flags="-dev -demo-mode"

--- a/deploy/crds/demo-hosts.yaml
+++ b/deploy/crds/demo-hosts.yaml
@@ -1,0 +1,232 @@
+# # Use this file with the -demo flag to the controller to produce 1
+# # host in each state.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-discovered-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-discovered
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-registration-error-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-registration-error
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.1:6233
+    credentialsName: demo-registration-error-secret
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-registering-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-registering
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.2:6233
+    credentialsName: demo-registering-secret
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-ready-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-ready
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.3:6233
+    credentialsName: demo-ready-secret
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-inspecting-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-inspecting
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.4:6233
+    credentialsName: demo-inspecting-secret
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-preparing-to-provision-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-preparing-to-provision
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.5:6233
+    credentialsName: demo-preparing-to-provision-secret
+  bootMACAddress: 00:c6:14:04:61:b2
+  online: true
+  userData:
+    namespace: openshift-machine-api
+    name: worker-user-data
+  image:
+    url: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+    checksum: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2.md5sum"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-available-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-available
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.7:6233
+    credentialsName: demo-available-secret
+  bootMACAddress: 00:c6:14:04:61:b2
+  userData:
+    namespace: openshift-machine-api
+    name: worker-user-data
+  image:
+    url: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+    checksum: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2.md5sum"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-provisioning-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-provisioning
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.6:6233
+    credentialsName: demo-provisioning-secret
+  bootMACAddress: 00:c6:14:04:61:b2
+  userData:
+    namespace: openshift-machine-api
+    name: worker-user-data
+  image:
+    url: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+    checksum: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2.md5sum"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-provisioned-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-provisioned
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.8:6233
+    credentialsName: demo-provisioned-secret
+  bootMACAddress: 00:c6:14:04:61:b2
+  userData:
+    namespace: openshift-machine-api
+    name: worker-user-data
+  image:
+    url: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+    checksum: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2.md5sum"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: demo-validation-error-secret
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm
+---
+apiVersion: metalkube.org/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: demo-validation-error
+spec:
+  online: true
+  bmc:
+    address: ipmi://192.168.122.8:6233
+    credentialsName: demo-validation-error-secret
+  bootMACAddress: 00:c6:14:04:61:b2
+  userData:
+    namespace: openshift-machine-api
+    name: worker-user-data
+  image:
+    url: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2"
+    checksum: "http://172.22.0.1/images/redhat-coreos-maipo-latest.qcow2.md5sum"

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -246,7 +246,7 @@ func (host *BareMetalHost) SetErrorMessage(message string) (dirty bool) {
 
 // ClearError removes any existing error message.
 func (host *BareMetalHost) ClearError() (dirty bool) {
-	if host.Status.OperationalStatus != OperationalStatusOK {
+	if host.Status.OperationalStatus == OperationalStatusError {
 		host.Status.OperationalStatus = OperationalStatusOK
 		dirty = true
 	}

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -3,7 +3,6 @@ package baremetalhost
 import (
 	"context"
 	"flag"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -459,31 +458,6 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (reconcile
 			return reconcile.Result{Requeue: true, RequeueAfter: provResult.RequeueAfter}, nil
 		}
 		return reconcile.Result{RequeueAfter: provResult.RequeueAfter}, nil
-	}
-
-	// If we reach this point we haven't encountered any issues
-	// communicating with the host, so ensure the error message field
-	// is cleared.
-	previousError := host.Status.ErrorMessage
-	if host.ClearError() {
-		if previousError != "" {
-			r.publishEvent(request, host,
-				"ClearedError", fmt.Sprintf("Resolved previous error condition : %s",
-					previousError))
-		} else {
-			r.publishEvent(request, host,
-				"ClearedError", "Resolved previous error condition")
-		}
-		if err := r.saveStatus(host); err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "failed to clear error")
-		}
-		if host.HasError() {
-			// We have tried to deprovision the host and that failed
-			// in a way we assume is not retryable, so do not proceed
-			// to any other steps.
-			reqLogger.Info("registration error")
-			return reconcile.Result{}, nil
-		}
 	}
 
 	// If we have nothing else to do and there is no LastUpdated

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -1,0 +1,354 @@
+package demo
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metalkube/baremetal-operator/pkg/bmc"
+	"github.com/metalkube/baremetal-operator/pkg/provisioner"
+)
+
+var log = logf.Log.WithName("demo")
+var deprovisionRequeueDelay = time.Second * 10
+var provisionRequeueDelay = time.Second * 10
+
+const (
+	registrationErrorHost    string = "demo-registration-error"
+	registeringHost          string = "demo-registering"
+	readyHost                string = "demo-ready"
+	inspectingHost           string = "demo-inspecting"
+	preparingToProvisionHost string = "demo-preparing-to-provision"
+	validationErrorHost      string = "demo-validation-error"
+	availableHost            string = "demo-available"
+	provisioningHost         string = "demo-provisioning"
+	provisionedHost          string = "demo-provisioned"
+)
+
+// Provisioner implements the provisioning.Provisioner interface
+// and uses Ironic to manage the host.
+type demoProvisioner struct {
+	// the host to be managed by this provisioner
+	host *metalkubev1alpha1.BareMetalHost
+	// the bmc credentials
+	bmcCreds bmc.Credentials
+	// a logger configured for this host
+	log logr.Logger
+	// an event publisher for recording significant events
+	publisher provisioner.EventPublisher
+}
+
+// New returns a new Ironic Provisioner
+func New(host *metalkubev1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (provisioner.Provisioner, error) {
+	p := &demoProvisioner{
+		host:      host,
+		bmcCreds:  bmcCreds,
+		log:       log.WithValues("host", host.Name),
+		publisher: publisher,
+	}
+	return p, nil
+}
+
+// ValidateManagementAccess tests the connection information for the
+// host to verify that the location and credentials work.
+func (p *demoProvisioner) ValidateManagementAccess() (result provisioner.Result, err error) {
+	p.log.Info("testing management access")
+
+	hostName := p.host.ObjectMeta.Name
+	if hostName == registrationErrorHost {
+		if p.host.Status.Provisioning.State != provisioner.StateRegistrationError {
+			p.log.Info("setting registration error")
+			p.host.SetErrorMessage("failed to register new host")
+			p.host.Status.Provisioning.State = provisioner.StateRegistrationError
+			p.publisher("RegistrationError", "Failed to register new host")
+			result.Dirty = true
+		}
+		// We don't need to set this as dirty because we've set an
+		// error so Reconcile() will stop
+		return result, nil
+	}
+
+	if hostName == registeringHost {
+		if p.host.Status.Provisioning.State != provisioner.StateRegistering {
+			p.log.Info("setting registering")
+			p.host.Status.Provisioning.State = provisioner.StateRegistering
+		}
+		// Always mark the host as dirty so it never moves past this
+		// point.
+		result.Dirty = true
+		result.RequeueAfter = time.Second * 5
+		return result, nil
+	}
+
+	result.RequeueAfter = time.Second * 5
+
+	if p.host.Status.Provisioning.ID == "" {
+		p.host.Status.Provisioning.ID = p.host.ObjectMeta.Name
+		p.host.Status.Provisioning.State = provisioner.StateReady
+		p.log.Info("setting provisioning id",
+			"provisioningID", p.host.Status.Provisioning.ID)
+		result.Dirty = true
+		p.publisher("Registered", "Registered new host")
+		return result, nil
+	}
+
+	return result, nil
+}
+
+// InspectHardware updates the HardwareDetails field of the host with
+// details of devices discovered on the hardware. It may be called
+// multiple times, and should return true for its dirty flag until the
+// inspection is completed.
+func (p *demoProvisioner) InspectHardware() (result provisioner.Result, err error) {
+	p.log.Info("inspecting hardware", "status", p.host.OperationalStatus())
+
+	hostName := p.host.ObjectMeta.Name
+
+	if p.host.OperationalStatus() != metalkubev1alpha1.OperationalStatusInspecting {
+		// The inspection just started.
+		p.publisher("InspectionStarted", "Hardware inspection started")
+		p.log.Info("starting inspection by setting state")
+		p.host.SetOperationalStatus(metalkubev1alpha1.OperationalStatusInspecting)
+		result.Dirty = true
+		return result, nil
+	}
+
+	if hostName == inspectingHost {
+		p.host.SetOperationalStatus(metalkubev1alpha1.OperationalStatusInspecting)
+		// set dirty so we don't allow the host to progress past this
+		// state in Reconcile()
+		result.Dirty = true
+		result.RequeueAfter = time.Second * 5
+		return result, nil
+	}
+
+	// The inspection is ongoing. We'll need to check the demo
+	// status for the server here until it is ready for us to get the
+	// inspection details. Simulate that for now by creating the
+	// hardware details struct as part of a second pass.
+	if p.host.Status.HardwareDetails == nil {
+		p.log.Info("continuing inspection by setting details")
+		p.host.Status.HardwareDetails =
+			&metalkubev1alpha1.HardwareDetails{
+				RAMGiB: 128,
+				NIC: []metalkubev1alpha1.NIC{
+					metalkubev1alpha1.NIC{
+						Name:      "nic-1",
+						Model:     "virt-io",
+						Network:   "Pod Networking",
+						MAC:       "some:mac:address",
+						IP:        "192.168.100.1",
+						SpeedGbps: 1,
+					},
+					metalkubev1alpha1.NIC{
+						Name:      "nic-2",
+						Model:     "e1000",
+						Network:   "Pod Networking",
+						MAC:       "some:other:mac:address",
+						IP:        "192.168.100.2",
+						SpeedGbps: 1,
+					},
+				},
+				Storage: []metalkubev1alpha1.Storage{
+					metalkubev1alpha1.Storage{
+						Name:    "disk-1 (boot)",
+						Type:    "SSD",
+						SizeGiB: 1024 * 93,
+						Model:   "Dell CFJ61",
+					},
+					metalkubev1alpha1.Storage{
+						Name:    "disk-2",
+						Type:    "SSD",
+						SizeGiB: 1024 * 93,
+						Model:   "Dell CFJ61",
+					},
+				},
+				CPUs: []metalkubev1alpha1.CPU{
+					metalkubev1alpha1.CPU{
+						Type:     "x86",
+						SpeedGHz: 3,
+					},
+				},
+			}
+		p.publisher("InspectionComplete", "Hardware inspection completed")
+		p.host.SetOperationalStatus(metalkubev1alpha1.OperationalStatusOK)
+		result.Dirty = true
+		return result, nil
+	}
+
+	return result, nil
+}
+
+// UpdateHardwareState fetches the latest hardware state of the server
+// and updates the HardwareDetails field of the host with details. It
+// is expected to do this in the least expensive way possible, such as
+// reading from a cache, and return dirty only if any state
+// information has changed.
+func (p *demoProvisioner) UpdateHardwareState() (result provisioner.Result, err error) {
+	p.log.Info("updating hardware state")
+	result.Dirty = false
+	return result, nil
+}
+
+// Provision writes the image from the host spec to the host. It may
+// be called multiple times, and should return true for its dirty flag
+// until the deprovisioning operation is completed.
+func (p *demoProvisioner) Provision(userData string) (result provisioner.Result, err error) {
+
+	hostName := p.host.ObjectMeta.Name
+	p.log.Info("provisioning image to host", "state", p.host.Status.Provisioning.State)
+
+	switch p.host.Status.Provisioning.State {
+	case provisioner.StatePreparingToProvision:
+	case provisioner.StateMakingAvailable:
+	case provisioner.StateProvisioning:
+	case provisioner.StateValidationError:
+	default:
+		p.log.Info("starting provisioning image to host")
+		p.publisher("ProvisioningStarted",
+			fmt.Sprintf("Image provisioning started for %s", p.host.Spec.Image.URL))
+		p.host.Status.Provisioning.State = provisioner.StatePreparingToProvision
+		result.Dirty = true
+		return result, nil
+	}
+
+	if hostName == preparingToProvisionHost {
+		p.log.Info("prepare host")
+		result.Dirty = true
+		result.RequeueAfter = time.Second * 5
+		return result, nil
+	}
+
+	if p.host.Status.Provisioning.State == provisioner.StatePreparingToProvision {
+		p.log.Info("making available")
+		p.host.Status.Provisioning.State = provisioner.StateMakingAvailable
+		result.Dirty = true
+		return result, nil
+	}
+
+	if hostName == availableHost {
+		p.log.Info("available host")
+		result.Dirty = true
+		result.RequeueAfter = time.Second * 5
+		return result, nil
+	}
+
+	if hostName == validationErrorHost {
+		p.log.Info("validation error host")
+		p.publisher("HostValidationError", "validation failed")
+		p.host.SetErrorMessage("validation failed")
+		p.host.Status.Provisioning.State = provisioner.StateValidationError
+		result.Dirty = true
+		return result, nil
+	}
+
+	if p.host.Status.Provisioning.State == provisioner.StateMakingAvailable {
+		p.log.Info("provisioning")
+		p.host.Status.Provisioning.State = provisioner.StateProvisioning
+		result.Dirty = true
+		return result, nil
+	}
+
+	if hostName == provisioningHost {
+		p.log.Info("provisioning host")
+		result.Dirty = true
+		result.RequeueAfter = time.Second * 5
+		return result, nil
+	}
+
+	if p.host.Status.Provisioning.State == provisioner.StateProvisioning {
+		p.publisher("ProvisioningComplete",
+			fmt.Sprintf("Image provisioning completed for %s", p.host.Spec.Image.URL))
+		p.log.Info("finished provisioning")
+		p.host.Status.Provisioning.Image = *p.host.Spec.Image
+		p.host.Status.Provisioning.State = provisioner.StateProvisioned
+		result.Dirty = true
+		return result, nil
+	}
+
+	return result, nil
+}
+
+// Deprovision prepares the host to be removed from the cluster. It
+// may be called multiple times, and should return true for its dirty
+// flag until the deprovisioning operation is completed.
+func (p *demoProvisioner) Deprovision(deleteIt bool) (result provisioner.Result, err error) {
+
+	hostName := p.host.ObjectMeta.Name
+	switch hostName {
+	default:
+		return result, nil
+	}
+
+	// p.log.Info("ensuring host is removed")
+
+	// result.RequeueAfter = deprovisionRequeueDelay
+
+	// // NOTE(dhellmann): In order to simulate a multi-step process,
+	// // modify some of the status data structures. This is likely not
+	// // necessary once we really have Demo doing the deprovisioning
+	// // and we can monitor it's status.
+
+	// if p.host.Status.HardwareDetails != nil {
+	// 	p.publisher("DeprovisionStarted", "Image deprovisioning started")
+	// 	p.log.Info("clearing hardware details")
+	// 	p.host.Status.HardwareDetails = nil
+	// 	result.Dirty = true
+	// 	return result, nil
+	// }
+
+	// if p.host.Status.Provisioning.ID != "" {
+	// 	p.log.Info("clearing provisioning id")
+	// 	p.host.Status.Provisioning.ID = ""
+	// 	result.Dirty = true
+	// 	return result, nil
+	// }
+
+	// p.publisher("DeprovisionComplete", "Image deprovisioning completed")
+	// return result, nil
+}
+
+// PowerOn ensures the server is powered on independently of any image
+// provisioning operation.
+func (p *demoProvisioner) PowerOn() (result provisioner.Result, err error) {
+
+	hostName := p.host.ObjectMeta.Name
+	switch hostName {
+	default:
+		return result, nil
+	}
+
+	// p.log.Info("ensuring host is powered on")
+
+	// if !p.host.Status.PoweredOn {
+	// 	p.host.Status.PoweredOn = true
+	// 	result.Dirty = true
+	// 	return result, nil
+	// }
+
+	// return result, nil
+}
+
+// PowerOff ensures the server is powered off independently of any image
+// provisioning operation.
+func (p *demoProvisioner) PowerOff() (result provisioner.Result, err error) {
+
+	hostName := p.host.ObjectMeta.Name
+	switch hostName {
+	default:
+		return result, nil
+	}
+
+	// p.log.Info("ensuring host is powered off")
+
+	// if p.host.Status.PoweredOn {
+	// 	p.host.Status.PoweredOn = false
+	// 	result.Dirty = true
+	// 	return result, nil
+	// }
+
+	// return result, nil
+}

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -126,6 +126,7 @@ func (p *fixtureProvisioner) InspectHardware() (result provisioner.Result, err e
 				},
 			}
 		p.publisher("InspectionComplete", "Hardware inspection completed")
+		p.host.SetOperationalStatus(metalkubev1alpha1.OperationalStatusOK)
 		result.Dirty = true
 		return result, nil
 	}

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -31,17 +31,7 @@ var provisionRequeueDelay = time.Second * 10
 var powerRequeueDelay = time.Second * 10
 
 const (
-	ironicEndpoint            = "http://localhost:6385/v1/"
-	stateNone                 = ""
-	stateRegistrationError    = "registration error"
-	stateRegistering          = "registering"
-	stateReady                = "ready"
-	statePreparingToProvision = "preparing to provision"
-	stateMakingAvailable      = "making host available"
-	stateValidationError      = "validation error"
-	stateProvisioning         = "provisioning"
-	stateProvisioned          = "provisioned"
-	stateDeprovisioning       = "deprovisioning"
+	ironicEndpoint = "http://localhost:6385/v1/"
 	// See nodes.Node.PowerState for details
 	powerOn   = "power on"
 	powerOff  = "power off"
@@ -255,7 +245,7 @@ func (p *ironicProvisioner) ValidateManagementAccess() (result provisioner.Resul
 		// cannot see the BMC or the credentials are wrong. Set the
 		// error message and return dirty, if we've changed something,
 		// so the status is stored.
-		p.status.State = stateRegistrationError
+		p.status.State = provisioner.StateRegistrationError
 		result.Dirty = p.host.SetErrorMessage(ironicNode.LastError) || result.Dirty
 		p.publisher("HostRegistrationError", ironicNode.LastError)
 		return result, nil
@@ -273,7 +263,7 @@ func (p *ironicProvisioner) ValidateManagementAccess() (result provisioner.Resul
 			"current", ironicNode.ProvisionState,
 			"target", ironicNode.TargetProvisionState,
 		)
-		p.status.State = stateRegistering
+		p.status.State = provisioner.StateRegistering
 		changeResult := nodes.ChangeProvisionState(
 			p.client,
 			ironicNode.UUID,
@@ -301,7 +291,7 @@ func (p *ironicProvisioner) ValidateManagementAccess() (result provisioner.Resul
 	if err != nil {
 		return result, errors.Wrap(err, "failed to check provision state")
 	}
-	if p.status.State == stateRegistering {
+	if p.status.State == provisioner.StateRegistering {
 		if ironicNode.ProvisionState != nodes.Manageable {
 			// If we're still waiting for the state to change in Ironic,
 			// return true to indicate that we're dirty and need to be
@@ -311,11 +301,11 @@ func (p *ironicProvisioner) ValidateManagementAccess() (result provisioner.Resul
 				"current", ironicNode.ProvisionState,
 				"target", ironicNode.TargetProvisionState,
 			)
-			p.status.State = stateRegistering
+			p.status.State = provisioner.StateRegistering
 			result.Dirty = true
 		} else {
 			// Mark the node as ready to be used
-			p.status.State = stateReady
+			p.status.State = provisioner.StateReady
 			result.Dirty = true
 		}
 	}
@@ -464,7 +454,7 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 	p.log.Info("provisioning image to host")
 
 	// The last time we were here we set the host in an error state.
-	if p.status.State == stateValidationError {
+	if p.status.State == provisioner.StateValidationError {
 		p.log.Info("stopping provisioning due to validation error")
 		return result, nil
 	}
@@ -481,7 +471,7 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 		p.log.Info("found error", "msg", ironicNode.LastError)
 		p.publisher("ProvisioningFailed",
 			fmt.Sprintf("Image provisioning failed: %s", ironicNode.LastError))
-		p.status.State = stateValidationError
+		p.status.State = provisioner.StateValidationError
 		result.Dirty = p.host.SetErrorMessage(ironicNode.LastError)
 		return result, nil
 	}
@@ -573,14 +563,14 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 
 		p.publisher("ProvisioningStarted",
 			fmt.Sprintf("Image provisioning started for %s", p.host.Spec.Image.URL))
-		p.status.State = statePreparingToProvision
+		p.status.State = provisioner.StatePreparingToProvision
 		result.Dirty = true
 		return result, nil
 	}
 
 	// Ironic has the settings it needs, see if it finds any issues
 	// with them.
-	if p.status.State == statePreparingToProvision {
+	if p.status.State == provisioner.StatePreparingToProvision {
 		ok, err := p.validateNode(ironicNode)
 		switch err.(type) {
 		case nil:
@@ -592,7 +582,7 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 			return result, errors.Wrap(err, "failed to validate host during registration")
 		}
 		if !ok {
-			p.status.State = stateValidationError
+			p.status.State = provisioner.StateValidationError
 			result.Dirty = true // validateNode() would have set the errors
 			return result, nil
 		}
@@ -621,13 +611,13 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 			return result, errors.Wrap(changeResult.Err,
 				"failed to change provisioning state to provide")
 		}
-		p.status.State = stateMakingAvailable
+		p.status.State = provisioner.StateMakingAvailable
 		result.Dirty = true
 		return result, nil
 	}
 
 	// Wait for the host to become available
-	if p.status.State == stateMakingAvailable {
+	if p.status.State == provisioner.StateMakingAvailable {
 		if ironicNode.ProvisionState != nodes.Available {
 			p.log.Info("waiting for host to become available",
 				"deploy step", ironicNode.DeployStep)
@@ -675,19 +665,19 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 			return result, errors.Wrap(changeResult.Err,
 				"failed to trigger provisioning")
 		}
-		p.status.State = stateProvisioning
+		p.status.State = provisioner.StateProvisioning
 		result.Dirty = true
 		return result, nil
 	}
 
 	// Wait for provisioning to be completed
-	if p.status.State == stateProvisioning {
+	if p.status.State == provisioner.StateProvisioning {
 		if ironicNode.ProvisionState == nodes.Active {
 			p.publisher("ProvisioningComplete",
 				fmt.Sprintf("Image provisioning completed for %s", p.host.Spec.Image.URL))
 			p.log.Info("finished provisioning")
 			p.status.Image = *p.host.Spec.Image
-			p.status.State = stateProvisioned
+			p.status.State = provisioner.StateProvisioned
 			result.Dirty = true
 			return result, nil
 		}
@@ -763,7 +753,7 @@ func (p *ironicProvisioner) Deprovision(deleteIt bool) (result provisioner.Resul
 				p.log.Info("clearing provisioning status")
 				p.status.Image.URL = ""
 				p.status.Image.Checksum = ""
-				p.status.State = stateNone
+				p.status.State = provisioner.StateNone
 				result.Dirty = true
 			}
 			return result, nil
@@ -815,7 +805,7 @@ func (p *ironicProvisioner) Deprovision(deleteIt bool) (result provisioner.Resul
 				"failed to trigger deprovisioning")
 		}
 		p.publisher("DeprovisionStarted", "Image deprovisioning started")
-		p.status.State = stateDeprovisioning
+		p.status.State = provisioner.StateDeprovisioning
 		result.Dirty = true
 		return result, nil
 	}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -66,3 +66,33 @@ type Result struct {
 	// Dirty is also true.
 	RequeueAfter time.Duration
 }
+
+const (
+	// StateNone means the state is unknown
+	StateNone = ""
+	// StateRegistrationError means there was an error registering the
+	// host with the backend
+	StateRegistrationError = "registration error"
+	// StateRegistering means we are telling the backend about the host
+	StateRegistering = "registering"
+	// StateReady means the host can be consumed
+	StateReady = "ready"
+	// StatePreparingToProvision means we are updating the host to
+	// receive its image
+	StatePreparingToProvision = "preparing to provision"
+	// StateMakingAvailable means we are making the host available to
+	// be provisioned
+	StateMakingAvailable = "making host available"
+	// StateValidationError means the provisioning instructions had an
+	// error
+	StateValidationError = "validation error"
+	// StateProvisioning means we are writing an image to the host's
+	// disk(s)
+	StateProvisioning = "provisioning"
+	// StateProvisioned means we have written an image to the host's
+	// disk(s)
+	StateProvisioned = "provisioned"
+	// StateDeprovisioning means we are removing an image from the
+	// host's disk(s)
+	StateDeprovisioning = "deprovisioning"
+)

--- a/tools/clean_demo_hosts.sh
+++ b/tools/clean_demo_hosts.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -x
+
+for host in $(oc get baremetalhosts --no-headers | grep '^demo-' | awk '{print $1}')
+do
+    oc delete baremetalhost $host
+done

--- a/tools/show_host_status.sh
+++ b/tools/show_host_status.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+oc get baremetalhosts -o=custom-columns='NAME:.metadata.name,STATE:.status.provisioning.state,OP:.status.operationalStatus,ERROR:.status.errorMessage'


### PR DESCRIPTION
In the course of building this demo provisioner, I found some additional ways to clean up the controller logic for error handling. I have prepared separate patches in a series so they are easier to review.