### PR TITLE
Fix CR reference in the docs

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -43,7 +43,7 @@ install the operator-sdk tools.
 6. Create the CR
 
     ```
-    kubectl apply -f deploy/crds/metalkube_v1alpha1_baremetalhost_cr.yaml
+    kubectl apply -f deploy/crds/example-host.yaml
     ```
 
 ## Running without Ironic


### PR DESCRIPTION
In the minikube section of the docs, the final step of creating a CR
references a file that no longer exists. Point it to example-host.yaml
instead.