### PR TITLE
Fix idrac driver_info format

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,9 +13,10 @@ necessary to manage and provision it.
 communicating over IPMI, this should be a URL of the form
 `ipmi://<host>:<port>` (an unadorned `<host>:<port>` is also accepted).
 Specifying the port is optional; the default port is 623. Dell iDRAC is also
-supported, by using the scheme `idrac+http://` (or just `idrac://`), or
-`idrac+https://`, in place of `http://` or `https://` (respectively) in the
-iDRAC URL.
+supported, by using the scheme `idrac://` (or `idrac+http://` to disable TLS)
+in place of `https://` in the iDRAC URL; only the hostname or IP address is
+required - `idrac://host.example` is equivalent to
+`idrac+https://host.example:443/wsman`.
 
 *bmc.credentials* -- A reference to a Secret containing the connection
 data, at least username and password, for the BMC.

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -279,8 +279,27 @@ func TestParseIDRACURLIPv6(t *testing.T) {
 	}
 }
 
+func TestParseIDRACURLNoSep(t *testing.T) {
+	T, H, P, A, err := getTypeHostPort("idrac:192.168.122.1")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if T != "idrac" {
+		t.Fatalf("unexpected type: %q", T)
+	}
+	if H != "192.168.122.1" {
+		t.Fatalf("unexpected hostname: %q", H)
+	}
+	if P != "" {
+		t.Fatalf("unexpected port: %q", P)
+	}
+	if A != "" {
+		t.Fatalf("unexpected path: %q", A)
+	}
+}
+
 func TestIDRACNeedsMAC(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://192.168.122.1/")
+	acc, err := NewAccessDetails("idrac://192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -290,7 +309,7 @@ func TestIDRACNeedsMAC(t *testing.T) {
 }
 
 func TestIDRACDriver(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://192.168.122.1/")
+	acc, err := NewAccessDetails("idrac://192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
@@ -301,35 +320,62 @@ func TestIDRACDriver(t *testing.T) {
 }
 
 func TestIDRACDriverInfo(t *testing.T) {
-	acc, err := NewAccessDetails("idrac://192.168.122.1/")
+	acc, err := NewAccessDetails("idrac://192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "http://192.168.122.1/" {
-		t.Fatalf("unexpected port: %v", di["ipmi_port"])
+	if di["drac_address"] != "192.168.122.1" {
+		t.Fatalf("unexpected address: %v", di["drac_address"])
+	}
+	if _, present := di["drac_port"]; present {
+		t.Fatalf("unexpected port: %v", di["drac_port"])
+	}
+	if _, present := di["drac_protocol"]; present {
+		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
+	}
+	if _, present := di["drac_path"]; present {
+		t.Fatalf("unexpected path: %v", di["drac_path"])
 	}
 }
 
 func TestIDRACDriverInfoHTTP(t *testing.T) {
-	acc, err := NewAccessDetails("idrac+http://192.168.122.1/")
+	acc, err := NewAccessDetails("idrac+http://192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "http://192.168.122.1/" {
-		t.Fatalf("unexpected port: %v", di["ipmi_port"])
+	if di["drac_address"] != "192.168.122.1" {
+		t.Fatalf("unexpected address: %v", di["drac_address"])
+	}
+	if _, present := di["drac_port"]; present {
+		t.Fatalf("unexpected port: %v", di["drac_port"])
+	}
+	if di["drac_protocol"] != "http" {
+		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
+	}
+	if _, present := di["drac_path"]; present {
+		t.Fatalf("unexpected path: %v", di["drac_path"])
 	}
 }
 
 func TestIDRACDriverInfoHTTPS(t *testing.T) {
-	acc, err := NewAccessDetails("idrac+https://192.168.122.1/")
+	acc, err := NewAccessDetails("idrac+https://192.168.122.1")
 	if err != nil {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "https://192.168.122.1/" {
-		t.Fatalf("unexpected port: %v", di["ipmi_port"])
+	if di["drac_address"] != "192.168.122.1" {
+		t.Fatalf("unexpected address: %v", di["drac_address"])
+	}
+	if _, present := di["drac_port"]; present {
+		t.Fatalf("unexpected port: %v", di["drac_port"])
+	}
+	if di["drac_protocol"] != "https" {
+		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
+	}
+	if _, present := di["drac_path"]; present {
+		t.Fatalf("unexpected path: %v", di["drac_path"])
 	}
 }
 
@@ -339,8 +385,17 @@ func TestIDRACDriverInfoPort(t *testing.T) {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "http://192.168.122.1:8080/foo" {
-		t.Fatalf("unexpected port: %v", di["ipmi_port"])
+	if di["drac_address"] != "192.168.122.1" {
+		t.Fatalf("unexpected address: %v", di["drac_address"])
+	}
+	if di["drac_port"] != "8080" {
+		t.Fatalf("unexpected port: %v", di["drac_port"])
+	}
+	if _, present := di["drac_protocol"]; present {
+		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
+	}
+	if di["drac_path"] != "/foo" {
+		t.Fatalf("unexpected path: %v", di["drac_path"])
 	}
 }
 
@@ -350,8 +405,17 @@ func TestIDRACDriverInfoIPv6(t *testing.T) {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "http://[fe80::fc33:62ff:fe83:8a76]/foo" {
-		t.Fatalf("unexpected port: %v", di["ipmi_port"])
+	if di["drac_address"] != "fe80::fc33:62ff:fe83:8a76" {
+		t.Fatalf("unexpected address: %v", di["drac_address"])
+	}
+	if _, present := di["drac_port"]; present {
+		t.Fatalf("unexpected port: %v", di["drac_port"])
+	}
+	if _, present := di["drac_protocol"]; present {
+		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
+	}
+	if di["drac_path"] != "/foo" {
+		t.Fatalf("unexpected path: %v", di["drac_path"])
 	}
 }
 
@@ -361,13 +425,22 @@ func TestIDRACDriverInfoIPv6Port(t *testing.T) {
 		t.Fatalf("unexpected parse error: %v", err)
 	}
 	di := acc.DriverInfo(Credentials{})
-	if di["drac_address"] != "http://[fe80::fc33:62ff:fe83:8a76]:8080/foo" {
-		t.Fatalf("unexpected port: %v", di["ipmi_port"])
+	if di["drac_address"] != "fe80::fc33:62ff:fe83:8a76" {
+		t.Fatalf("unexpected address: %v", di["drac_address"])
+	}
+	if di["drac_port"] != "8080" {
+		t.Fatalf("unexpected port: %v", di["drac_port"])
+	}
+	if _, present := di["drac_protocol"]; present {
+		t.Fatalf("unexpected protocol: %v", di["drac_protocol"])
+	}
+	if di["drac_path"] != "/foo" {
+		t.Fatalf("unexpected path: %v", di["drac_path"])
 	}
 }
 
 func TestUnknownType(t *testing.T) {
-	acc, err := NewAccessDetails("foo://192.168.122.1/")
+	acc, err := NewAccessDetails("foo://192.168.122.1")
 	if err == nil || acc != nil {
 		t.Fatal("unexpected parse success")
 	}

--- a/pkg/bmc/idrac.go
+++ b/pkg/bmc/idrac.go
@@ -1,8 +1,6 @@
 package bmc
 
 import (
-	"fmt"
-	"net/url"
 	"strings"
 )
 
@@ -33,29 +31,22 @@ func (a *iDracAccessDetails) Driver() string {
 // expected to add any other information that might be needed (such as
 // the kernel and ramdisk locations).
 func (a *iDracAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
-	host := a.hostname
-	if strings.ContainsRune(host, ':') {
-		// Hostname is an IPv6 address
-		host = fmt.Sprintf("[%s]", host)
-	}
-	if a.portNum != "" {
-		host = fmt.Sprintf("%s:%s", host, a.portNum)
-	}
-
-	scheme := "http"
-	if strings.HasSuffix(a.bmcType, "https") {
-		scheme = "https"
-	}
-
-	address := url.URL{
-		Scheme: scheme,
-		Host:   host,
-		Path:   a.path,
-	}
-
-	return map[string]interface{}{
+	result := map[string]interface{}{
 		"drac_username": bmcCreds.Username,
 		"drac_password": bmcCreds.Password,
-		"drac_address":  address.String(),
+		"drac_address":  a.hostname,
 	}
+
+	schemes := strings.Split(a.bmcType, "+")
+	if len(schemes) > 1 {
+		result["drac_protocol"] = schemes[1]
+	}
+	if a.portNum != "" {
+		result["drac_port"] = a.portNum
+	}
+	if a.path != "" {
+		result["drac_path"] = a.path
+	}
+
+	return result
 }


### PR DESCRIPTION
The `drac_address` is not actually a URL as [previously indicated](https://review.openstack.org/648493) in the Ironic docs. Rather, it is just the hostname and the other components of the URL can optionally be passed as `drac_protocol`, `drac_port`, and `drac_path`.