### PR TITLE
Split Reconcile() into phases

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -290,12 +290,10 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (reconcile
 			continue
 		}
 
-		if phaseResult.Requeue {
-			ctx.log.Info("saving host status")
-			if err = r.saveStatus(host); err != nil {
-				return reconcile.Result{}, errors.Wrap(err,
-					fmt.Sprintf("failed to save host status after %s phase", phase.name))
-			}
+		ctx.log.Info("saving host status")
+		if err = r.saveStatus(host); err != nil {
+			return reconcile.Result{}, errors.Wrap(err,
+				fmt.Sprintf("failed to save host status after %s phase", phase.name))
 		}
 
 		if host.HasError() {


### PR DESCRIPTION
This is an attempt to restructure the Reconcile() method based on a series of phases so we can add consistent handling for the need to save data or report errors. I have it split up into separate commits to make reviews easier, and the tests all worked at each commit point.