### PR TITLE
publish event when the BMC access can be verified

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -409,6 +409,8 @@ func (r *ReconcileBareMetalHost) phaseValidateAccess(info reconcileInfo) (result
 	info.log.Info("updating credentials success status fields")
 	info.host.UpdateGoodCredentials(*info.bmcCredsSecret)
 
+	info.publisher("BMCAccessValidated", "Verified access to BMC")
+
 	result = &reconcile.Result{
 		Requeue:      true,
 		RequeueAfter: provResult.RequeueAfter,


### PR DESCRIPTION
The BMC credentials can be changed over time, so track successful
updates using operational events.