### PR TITLE
move user data fetching into a callback

### DIFF
--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -196,7 +196,7 @@ func (p *demoProvisioner) UpdateHardwareState() (result provisioner.Result, err 
 // Provision writes the image from the host spec to the host. It may
 // be called multiple times, and should return true for its dirty flag
 // until the deprovisioning operation is completed.
-func (p *demoProvisioner) Provision(userData string) (result provisioner.Result, err error) {
+func (p *demoProvisioner) Provision(getUserData provisioner.UserDataSource) (result provisioner.Result, err error) {
 
 	hostName := p.host.ObjectMeta.Name
 	p.log.Info("provisioning image to host", "state", p.host.Status.Provisioning.State)

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -150,7 +150,7 @@ func (p *fixtureProvisioner) UpdateHardwareState() (result provisioner.Result, e
 // Provision writes the image from the host spec to the host. It may
 // be called multiple times, and should return true for its dirty flag
 // until the deprovisioning operation is completed.
-func (p *fixtureProvisioner) Provision(userData string) (result provisioner.Result, err error) {
+func (p *fixtureProvisioner) Provision(getUserData provisioner.UserDataSource) (result provisioner.Result, err error) {
 	p.log.Info("provisioning image to host",
 		"state", p.host.Status.Provisioning.State)
 

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -448,7 +448,7 @@ func checksumIsURL(checksumURL string) (bool, error) {
 // Provision writes the image from the host spec to the host. It may
 // be called multiple times, and should return true for its dirty flag
 // until the deprovisioning operation is completed.
-func (p *ironicProvisioner) Provision(userData string) (result provisioner.Result, err error) {
+func (p *ironicProvisioner) Provision(getUserData provisioner.UserDataSource) (result provisioner.Result, err error) {
 	var ironicNode *nodes.Node
 
 	p.log.Info("provisioning image to host", "state", p.host.Status.Provisioning.State)
@@ -643,6 +643,10 @@ func (p *ironicProvisioner) Provision(userData string) (result provisioner.Resul
 		// able to accept the user data string directly, without
 		// building the ISO image first.
 		var configDriveData string
+		userData, err := getUserData()
+		if err != nil {
+			return result, errors.Wrap(err, "could not retrieve user data")
+		}
 		if userData != "" {
 			configDrive := nodeutils.ConfigDrive{
 				UserData: nodeutils.UserDataString(userData),

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -18,6 +18,10 @@ type EventPublisher func(reason, message string)
 // Factory is the interface for creating new Provisioner objects.
 type Factory func(host *metalkubev1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publish EventPublisher) (Provisioner, error)
 
+// UserDataSource is the interface for a function to retrieve user
+// data for a host being provisioned.
+type UserDataSource func() (string, error)
+
 // Provisioner holds the state information for talking to the
 // provisioning backend.
 type Provisioner interface {
@@ -41,7 +45,7 @@ type Provisioner interface {
 	// Provision writes the image from the host spec to the host. It
 	// may be called multiple times, and should return true for its
 	// dirty flag until the deprovisioning operation is completed.
-	Provision(userData string) (result Result, err error)
+	Provision(getUserData UserDataSource) (result Result, err error)
 
 	// Deprovision prepares the host to be removed from the cluster. It
 	// may be called multiple times, and should return true for its dirty


### PR DESCRIPTION
Rather than fetch the user data every time we reconcile the host
during provisioning, use a callback to allow the provisioner to
request the data when it is actually needed.