### PR TITLE
define type for provisioning state values

### DIFF
--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -36,6 +36,53 @@ const (
 	OperationalStatusError OperationalStatus = "error"
 )
 
+// ProvisioningState defines the states the provisioner will report
+// the host has having.
+type ProvisioningState string
+
+const (
+	// StateNone means the state is unknown
+	StateNone ProvisioningState = ""
+
+	// StateRegistrationError means there was an error registering the
+	// host with the backend
+	StateRegistrationError ProvisioningState = "registration error"
+
+	// StateRegistering means we are telling the backend about the host
+	StateRegistering ProvisioningState = "registering"
+
+	// StateReady means the host can be consumed
+	StateReady ProvisioningState = "ready"
+
+	// StatePreparingToProvision means we are updating the host to
+	// receive its image
+	StatePreparingToProvision ProvisioningState = "preparing to provision"
+
+	// StateMakingAvailable means we are making the host available to
+	// be provisioned
+	StateMakingAvailable ProvisioningState = "making host available"
+
+	// StateValidationError means the provisioning instructions had an
+	// error
+	StateValidationError ProvisioningState = "validation error"
+
+	// StateProvisioning means we are writing an image to the host's
+	// disk(s)
+	StateProvisioning ProvisioningState = "provisioning"
+
+	// StateProvisioned means we have written an image to the host's
+	// disk(s)
+	StateProvisioned ProvisioningState = "provisioned"
+
+	// StateDeprovisioning means we are removing an image from the
+	// host's disk(s)
+	StateDeprovisioning ProvisioningState = "deprovisioning"
+
+	// StateInspecting means we are running the agent on the host to
+	// learn about the hardware components available there
+	StateInspecting ProvisioningState = "inspecting"
+)
+
 // BMCDetails contains the information necessary to communicate with
 // the bare metal controller module on host.
 type BMCDetails struct {
@@ -189,10 +236,12 @@ type BareMetalHostStatus struct {
 
 // ProvisionStatus holds the state information for a single target.
 type ProvisionStatus struct {
-	// FIXME(dhellmann): This should be an enum of some sort.
-	State string `json:"state"`
-	// The machine's UUID from ironic
+	// An indiciator for what the provisioner is doing with the host.
+	State ProvisioningState `json:"state"`
+
+	// The machine's UUID from the underlying provisioning tool
 	ID string `json:"ID"`
+
 	// Image holds the details of the last image successfully
 	// provisioned to the host.
 	Image Image `json:"image,omitempty"`

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -405,7 +405,7 @@ func (r *ReconcileBareMetalHost) phaseValidateAccess(info *reconcileInfo) (resul
 		return nil, errors.Wrap(err, "failed to validate BMC access")
 	}
 
-	if info.host.Status.Provisioning.State == provisioner.StateRegistrationError {
+	if info.host.Status.Provisioning.State == metalkubev1alpha1.StateRegistrationError {
 		// We have tried to register and validate the host and that
 		// failed. We have to return Requeue=true to ensure the host
 		// object is saved before the main loop stops when it sees the

--- a/pkg/provisioner/demo/demo.go
+++ b/pkg/provisioner/demo/demo.go
@@ -59,10 +59,10 @@ func (p *demoProvisioner) ValidateManagementAccess() (result provisioner.Result,
 
 	hostName := p.host.ObjectMeta.Name
 	if hostName == registrationErrorHost {
-		if p.host.Status.Provisioning.State != provisioner.StateRegistrationError {
+		if p.host.Status.Provisioning.State != metalkubev1alpha1.StateRegistrationError {
 			p.log.Info("setting registration error")
 			p.host.SetErrorMessage("failed to register new host")
-			p.host.Status.Provisioning.State = provisioner.StateRegistrationError
+			p.host.Status.Provisioning.State = metalkubev1alpha1.StateRegistrationError
 			p.publisher("RegistrationError", "Failed to register new host")
 			result.Dirty = true
 		}
@@ -72,9 +72,9 @@ func (p *demoProvisioner) ValidateManagementAccess() (result provisioner.Result,
 	}
 
 	if hostName == registeringHost {
-		if p.host.Status.Provisioning.State != provisioner.StateRegistering {
+		if p.host.Status.Provisioning.State != metalkubev1alpha1.StateRegistering {
 			p.log.Info("setting registering")
-			p.host.Status.Provisioning.State = provisioner.StateRegistering
+			p.host.Status.Provisioning.State = metalkubev1alpha1.StateRegistering
 		}
 		// Always mark the host as dirty so it never moves past this
 		// point.
@@ -87,7 +87,7 @@ func (p *demoProvisioner) ValidateManagementAccess() (result provisioner.Result,
 
 	if p.host.Status.Provisioning.ID == "" {
 		p.host.Status.Provisioning.ID = p.host.ObjectMeta.Name
-		p.host.Status.Provisioning.State = provisioner.StateReady
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateReady
 		p.log.Info("setting provisioning id",
 			"provisioningID", p.host.Status.Provisioning.ID)
 		result.Dirty = true
@@ -107,17 +107,17 @@ func (p *demoProvisioner) InspectHardware() (result provisioner.Result, err erro
 
 	hostName := p.host.ObjectMeta.Name
 
-	if p.host.Status.Provisioning.State != provisioner.StateInspecting {
+	if p.host.Status.Provisioning.State != metalkubev1alpha1.StateInspecting {
 		// The inspection just started.
 		p.publisher("InspectionStarted", "Hardware inspection started")
 		p.log.Info("starting inspection by setting state")
-		p.host.Status.Provisioning.State = provisioner.StateInspecting
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateInspecting
 		result.Dirty = true
 		return result, nil
 	}
 
 	if hostName == inspectingHost {
-		p.host.Status.Provisioning.State = provisioner.StateInspecting
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateInspecting
 		// set dirty so we don't allow the host to progress past this
 		// state in Reconcile()
 		result.Dirty = true
@@ -202,15 +202,15 @@ func (p *demoProvisioner) Provision(getUserData provisioner.UserDataSource) (res
 	p.log.Info("provisioning image to host", "state", p.host.Status.Provisioning.State)
 
 	switch p.host.Status.Provisioning.State {
-	case provisioner.StatePreparingToProvision:
-	case provisioner.StateMakingAvailable:
-	case provisioner.StateProvisioning:
-	case provisioner.StateValidationError:
+	case metalkubev1alpha1.StatePreparingToProvision:
+	case metalkubev1alpha1.StateMakingAvailable:
+	case metalkubev1alpha1.StateProvisioning:
+	case metalkubev1alpha1.StateValidationError:
 	default:
 		p.log.Info("starting provisioning image to host")
 		p.publisher("ProvisioningStarted",
 			fmt.Sprintf("Image provisioning started for %s", p.host.Spec.Image.URL))
-		p.host.Status.Provisioning.State = provisioner.StatePreparingToProvision
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StatePreparingToProvision
 		result.Dirty = true
 		return result, nil
 	}
@@ -222,9 +222,9 @@ func (p *demoProvisioner) Provision(getUserData provisioner.UserDataSource) (res
 		return result, nil
 	}
 
-	if p.host.Status.Provisioning.State == provisioner.StatePreparingToProvision {
+	if p.host.Status.Provisioning.State == metalkubev1alpha1.StatePreparingToProvision {
 		p.log.Info("making available")
-		p.host.Status.Provisioning.State = provisioner.StateMakingAvailable
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateMakingAvailable
 		result.Dirty = true
 		return result, nil
 	}
@@ -240,14 +240,14 @@ func (p *demoProvisioner) Provision(getUserData provisioner.UserDataSource) (res
 		p.log.Info("validation error host")
 		p.publisher("HostValidationError", "validation failed")
 		p.host.SetErrorMessage("validation failed")
-		p.host.Status.Provisioning.State = provisioner.StateValidationError
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateValidationError
 		result.Dirty = true
 		return result, nil
 	}
 
-	if p.host.Status.Provisioning.State == provisioner.StateMakingAvailable {
+	if p.host.Status.Provisioning.State == metalkubev1alpha1.StateMakingAvailable {
 		p.log.Info("provisioning")
-		p.host.Status.Provisioning.State = provisioner.StateProvisioning
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateProvisioning
 		result.Dirty = true
 		return result, nil
 	}
@@ -259,12 +259,12 @@ func (p *demoProvisioner) Provision(getUserData provisioner.UserDataSource) (res
 		return result, nil
 	}
 
-	if p.host.Status.Provisioning.State == provisioner.StateProvisioning {
+	if p.host.Status.Provisioning.State == metalkubev1alpha1.StateProvisioning {
 		p.publisher("ProvisioningComplete",
 			fmt.Sprintf("Image provisioning completed for %s", p.host.Spec.Image.URL))
 		p.log.Info("finished provisioning")
 		p.host.Status.Provisioning.Image = *p.host.Spec.Image
-		p.host.Status.Provisioning.State = provisioner.StateProvisioned
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateProvisioned
 		result.Dirty = true
 		return result, nil
 	}

--- a/pkg/provisioner/fixture/fixture.go
+++ b/pkg/provisioner/fixture/fixture.go
@@ -68,11 +68,11 @@ func (p *fixtureProvisioner) ValidateManagementAccess() (result provisioner.Resu
 func (p *fixtureProvisioner) InspectHardware() (result provisioner.Result, err error) {
 	p.log.Info("inspecting hardware", "status", p.host.OperationalStatus())
 
-	if p.host.Status.Provisioning.State != provisioner.StateInspecting {
+	if p.host.Status.Provisioning.State != metalkubev1alpha1.StateInspecting {
 		// The inspection just started.
 		p.publisher("InspectionStarted", "Hardware inspection started")
 		p.log.Info("starting inspection by setting state")
-		p.host.Status.Provisioning.State = provisioner.StateInspecting
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateInspecting
 		result.Dirty = true
 		return result, nil
 	}
@@ -126,7 +126,7 @@ func (p *fixtureProvisioner) InspectHardware() (result provisioner.Result, err e
 				},
 			}
 		p.publisher("InspectionComplete", "Hardware inspection completed")
-		p.host.Status.Provisioning.State = provisioner.StateReady
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateReady
 		result.Dirty = true
 		return result, nil
 	}
@@ -160,18 +160,18 @@ func (p *fixtureProvisioner) Provision(getUserData provisioner.UserDataSource) (
 	// multi-step process to ensure that multiple cycles through the
 	// reconcile loop work properly.
 
-	if p.host.Status.Provisioning.State == provisioner.StateReady {
+	if p.host.Status.Provisioning.State == metalkubev1alpha1.StateReady {
 		p.publisher("ProvisioningStarted", "Image provisioning started")
 		p.log.Info("moving to step1")
-		p.host.Status.Provisioning.State = provisioner.StateProvisioning
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateProvisioning
 		result.Dirty = true
 		return result, nil
 	}
 
-	if p.host.Status.Provisioning.State == provisioner.StateProvisioning {
+	if p.host.Status.Provisioning.State == metalkubev1alpha1.StateProvisioning {
 		p.publisher("ProvisioningComplete", "Image provisioning completed")
 		p.log.Info("moving to done")
-		p.host.Status.Provisioning.State = provisioner.StateProvisioned
+		p.host.Status.Provisioning.State = metalkubev1alpha1.StateProvisioned
 		p.host.Status.Provisioning.Image = *p.host.Spec.Image
 		result.Dirty = true
 		return result, nil

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -70,36 +70,3 @@ type Result struct {
 	// Dirty is also true.
 	RequeueAfter time.Duration
 }
-
-const (
-	// StateNone means the state is unknown
-	StateNone = ""
-	// StateRegistrationError means there was an error registering the
-	// host with the backend
-	StateRegistrationError = "registration error"
-	// StateRegistering means we are telling the backend about the host
-	StateRegistering = "registering"
-	// StateReady means the host can be consumed
-	StateReady = "ready"
-	// StatePreparingToProvision means we are updating the host to
-	// receive its image
-	StatePreparingToProvision = "preparing to provision"
-	// StateMakingAvailable means we are making the host available to
-	// be provisioned
-	StateMakingAvailable = "making host available"
-	// StateValidationError means the provisioning instructions had an
-	// error
-	StateValidationError = "validation error"
-	// StateProvisioning means we are writing an image to the host's
-	// disk(s)
-	StateProvisioning = "provisioning"
-	// StateProvisioned means we have written an image to the host's
-	// disk(s)
-	StateProvisioned = "provisioned"
-	// StateDeprovisioning means we are removing an image from the
-	// host's disk(s)
-	StateDeprovisioning = "deprovisioning"
-	// StateInspecting means we are running the agent on the host to
-	// learn about the hardware components available there
-	StateInspecting = "inspecting"
-)


### PR DESCRIPTION
Define a type to constraint the values for the provisioning state
field. In order to use the type in the host API and provisioner, we
have to define it in the host API module to avoid a circular reference
between the two modules.