### PR TITLE
Support changing the provisioned image

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -158,10 +158,7 @@ Several conditions must be met in order to initiate provisioning.
 1. The host `spec.image.url` field must contain a URL for a valid
    image file that is visible from within the cluster and from the
    host receiving the image.
-2. The host must not have an image provisioned, as reflected by the
-   `status.provisioning.image.URL` field being empty. To reuse an
-   existing host with a different image, deprovision the host first.
-3. The host must have `online` set to `true` so that the operator will
+2. The host must have `online` set to `true` so that the operator will
    keep the host powered on.
 
 To initiate deprovisioning, clear the image URL from the host spec.

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -413,8 +413,6 @@ func (host *BareMetalHost) NeedsProvisioning() bool {
 		// We have an image set, but not provisioned.
 		return true
 	}
-	// FIXME(dhellmann): Compare the provisioned image against the one
-	// we are supposed to have to make sure they match.
 	return false
 }
 
@@ -427,7 +425,7 @@ func (host *BareMetalHost) NeedsDeprovisioning() bool {
 	if host.Spec.Image == nil {
 		return true
 	}
-	if host.Spec.Image.URL == "" {
+	if host.Spec.Image.URL != host.Status.Provisioning.Image.URL {
 		return true
 	}
 	return false

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types_test.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types_test.go
@@ -193,3 +193,109 @@ func TestHostNeedsProvisioning(t *testing.T) {
 		t.Error("expected to not need provisioning")
 	}
 }
+
+func TestHostNeedsDeprovisioning(t *testing.T) {
+	hostYes := BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhost",
+			Namespace: "myns",
+		},
+		Spec: BareMetalHostSpec{
+			Image: &Image{
+				URL: "not-empty",
+			},
+			Online: true,
+		},
+	}
+	if hostYes.NeedsDeprovisioning() {
+		t.Error("expected to not need deprovisioning")
+	}
+
+	hostNoURL := BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhost",
+			Namespace: "myns",
+		},
+		Spec: BareMetalHostSpec{
+			Image:  &Image{},
+			Online: true,
+		},
+	}
+	if hostNoURL.NeedsDeprovisioning() {
+		t.Error("expected to not need deprovisioning")
+	}
+
+	hostNoImage := BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhost",
+			Namespace: "myns",
+		},
+		Spec: BareMetalHostSpec{
+			Online: true,
+		},
+	}
+	if hostNoImage.NeedsDeprovisioning() {
+		t.Error("expected to not need deprovisioning")
+	}
+
+	hostOffline := BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhost",
+			Namespace: "myns",
+		},
+		Spec: BareMetalHostSpec{
+			Image: &Image{
+				URL: "not-empty",
+			},
+		},
+	}
+	if hostOffline.NeedsDeprovisioning() {
+		t.Error("expected to not need deprovisioning")
+	}
+
+	hostAlreadyProvisioned := BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhost",
+			Namespace: "myns",
+		},
+		Spec: BareMetalHostSpec{
+			Image: &Image{
+				URL: "same",
+			},
+			Online: true,
+		},
+		Status: BareMetalHostStatus{
+			Provisioning: ProvisionStatus{
+				Image: Image{
+					URL: "same",
+				},
+			},
+		},
+	}
+	if hostAlreadyProvisioned.NeedsDeprovisioning() {
+		t.Error("expected to not need deprovisioning")
+	}
+
+	hostChangedImage := BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhost",
+			Namespace: "myns",
+		},
+		Spec: BareMetalHostSpec{
+			Image: &Image{
+				URL: "not-empty",
+			},
+			Online: true,
+		},
+		Status: BareMetalHostStatus{
+			Provisioning: ProvisionStatus{
+				Image: Image{
+					URL: "also-not-empty",
+				},
+			},
+		},
+	}
+	if !hostChangedImage.NeedsDeprovisioning() {
+		t.Error("expected to need deprovisioning")
+	}
+}


### PR DESCRIPTION
Previously to change the provisioned image, you would have to first set
the image URL to "" and wait for deprovisioning to complete before
reprovisioning with a new image URL. With this change, a change to the
image URL will cause the server to be deprovisioned and reprovisioned
with the new image.