### PR TITLE
add printer columns to the CRD

### DIFF
--- a/deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml
+++ b/deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml
@@ -13,3 +13,24 @@ spec:
   version: v1alpha1
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - JSONPath: .status.operationalStatus
+    description: Operational status
+    name: Status
+    type: string
+  - JSONPath: .status.provisioning.state
+    description: Provisioning status
+    name: Provisioning Status
+    type: string
+  - JSONPath: .spec.machineRef.name
+    description: Machine
+    name: Machine using this host
+    type: string
+  - JSONPath: .spec.bmc.address
+    description: Address of management controler
+    name: BMC
+    type: string
+  - JSONPath: .status.errorMessage
+    description: Most recent error
+    name: Error
+    type: string


### PR DESCRIPTION
Add a few columns with useful details about the host so that 'oc get'
or 'kubectl get' will report more than the name and age.