### PR TITLE
Do not log verbose tracebacks when bmc secret is missing

### DIFF
--- a/pkg/bmc/credentials.go
+++ b/pkg/bmc/credentials.go
@@ -1,37 +1,190 @@
 package bmc
 
-const (
-	// MissingCredentialsMsg is returned as a validation failure
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Error is the error type usually returned by functions in the bmc
+// package. It describes the host, whether or not this is a fatal error,
+// and any host error messages that should be set as well as the actual
+// error.
+type Error struct {
+	Host             *metalkubev1alpha1.BareMetalHost // the host this error is for
+	SecretPath       string                           // the secret name
+	DelayRequeue     bool                             // whether or not we should reqeue after this error
+	SetHostError     bool                             // whether or not this error should result in a host.setErrorMessage()
+	HostErrorMessage string                           // optional host error message to use for host.setErrorMessage()
+	Err              error                            // Error is the error that occurred during the operation
+}
+
+func (e *Error) getErr() error {
+	return e.Err
+}
+
+func (e *Error) Error() string {
+
+	if e == nil {
+		return "<nil>"
+	}
+
+	s := ""
+
+	if e.Host.Name != "" {
+		s += fmt.Sprintf("[host=%q]", e.Host.GetName())
+	}
+
+	if e.DelayRequeue == true {
+		s += " " + "[DelayRequeue=true]"
+	}
+
+	if e.SetHostError == true {
+		s += " " + "[SetHostError=true]"
+	}
+
+	s += " " + fmt.Sprintf("[secret=%q]", e.SecretPath)
+
+	s += ": " + e.Err.Error()
+
+	return s
+}
+
+// Various errors contained in bmcError
+var (
+
+	// errMissingCredentials is returned as a validation failure
 	// reason when there are no credentials at all.
-	MissingCredentialsMsg string = "Missing BMC connection details: Credentials"
+	ErrMissingCredentials = errors.New("Missing BMC connection details: Credentials")
 
-	// MissingAddressMsg is returned as a validation failure
+	// errMissingAddress is returned as a validation failure
 	// reason when there is no address for the BMC.
-	MissingAddressMsg string = "Missing BMC connection details: Address"
+	ErrMissingAddress = errors.New("Missing BMC connection details: Address")
 
-	// MissingUsernameMsg is returned as a validation failure reason
+	// errMissingUsername is returned as a validation failure reason
 	// when the credentials do not include a "username" field.
-	MissingUsernameMsg string = "Missing BMC connection details: 'username' in credentials"
+	ErrMissingUsername = errors.New("Missing BMC connection details: 'username' in credentials")
 
-	// MissingPasswordMsg is returned as a validation failure reason
+	// errMissingPassword is returned as a validation failure reason
 	// when the credentials do not include a "password" field.
-	MissingPasswordMsg string = "Missing BMC connection details: 'password' in credentials"
+	ErrMissingPassword = errors.New("Missing BMC connection details: 'password' in credentials")
+
+	// errMissingBMCSecret is returned when the BMC k8s secret
+	// returns a NotFound
+	ErrMissingBMCSecret = errors.New("Missing BMC k8s secret")
+
+	// errFailedToRetrieveBMCSecret is returned when the BMC k8s secret
+	// returns a NotFound
+	ErrFailedToRetrieveBMCSecret = errors.New("Temporary failure in retrieving BMC k8s secret")
 )
 
 // Credentials holds the information for authenticating with the BMC.
 type Credentials struct {
-	Username string
-	Password string
+	Host            *metalkubev1alpha1.BareMetalHost //	the host these credentials are for
+	Secret          *corev1.Secret                   // the actual secret for these credentials
+	SecretName      string                           // the secret name
+	SecretNameSpace string                           // the secret namespace
+	SecretPath      string                           // namespace + "/" + name
+	Username        string                           // the username for the BMC connection
+	Password        string                           // the password for the BMC connection
 }
 
-// AreValid returns a boolean indicating whether the credentials are
-// valid, and if false a string explaining why not.
-func (creds Credentials) AreValid() (bool, string) {
-	if creds.Username == "" {
-		return false, MissingUsernameMsg
+// NewCredentials is the proper way to create and return a Credentials object
+// containing the BMC credentials for a given host
+func NewCredentials(k8sClient client.Client, host *metalkubev1alpha1.BareMetalHost) (bmcCreds *Credentials, err error) {
+
+	// Handle missing BMC address
+	if host.Spec.BMC.Address == "" {
+
+		return nil, &Error{
+			Err:              ErrMissingAddress,
+			DelayRequeue:     true,
+			Host:             host,
+			SecretPath:       host.Spec.BMC.CredentialsName,
+			SetHostError:     true,
+			HostErrorMessage: ErrMissingAddress.Error() + " for host " + host.Name}
 	}
-	if creds.Password == "" {
-		return false, MissingPasswordMsg
+
+	// Handle empty BMC credentials field
+	if host.Spec.BMC.CredentialsName == "" {
+
+		return nil, &Error{
+			Err:              ErrMissingCredentials,
+			DelayRequeue:     true,
+			Host:             host,
+			SecretPath:       host.Spec.BMC.CredentialsName,
+			SetHostError:     true,
+			HostErrorMessage: ErrMissingCredentials.Error() + " for host " + host.Name}
+
 	}
-	return true, ""
+
+	// Retrieve the BMC Secret
+	secretKey := host.CredentialsKey()
+
+	// Manufacturer an empty k8s secret
+	bmcCredsSecret := &corev1.Secret{}
+
+	err = k8sClient.Get(context.TODO(), secretKey, bmcCredsSecret)
+	if err != nil {
+
+		// We need to handle the case where the secret is not found
+		// and distinguish that from a transient error
+
+		if k8serrors.IsNotFound(err) {
+
+			return nil, &Error{
+				Err:              ErrMissingBMCSecret,
+				DelayRequeue:     true,
+				Host:             host,
+				SecretPath:       host.Spec.BMC.CredentialsName,
+				SetHostError:     true,
+				HostErrorMessage: ErrMissingBMCSecret.Error() + " with secret " + host.Spec.BMC.CredentialsName}
+		}
+
+		return nil, &Error{
+			Err:          ErrFailedToRetrieveBMCSecret,
+			DelayRequeue: false,
+			Host:         host,
+			SecretPath:   bmcCredsSecret.Namespace + "/" + bmcCredsSecret.Name}
+
+	}
+
+	// extract the username and password from the secret
+	username := string(bmcCredsSecret.Data["username"])
+	password := string(bmcCredsSecret.Data["password"])
+
+	// final check for empty fields
+	if username == "" {
+		return nil, &Error{
+			Err:              ErrMissingUsername,
+			DelayRequeue:     false,
+			Host:             host,
+			SecretPath:       bmcCredsSecret.Namespace + "/" + bmcCredsSecret.Name,
+			SetHostError:     true,
+			HostErrorMessage: ErrMissingUsername.Error() + " with secret " + host.Spec.BMC.CredentialsName}
+	}
+
+	if password == "" {
+		return nil, &Error{
+			Err:              ErrMissingPassword,
+			DelayRequeue:     false,
+			Host:             host,
+			SecretPath:       bmcCredsSecret.Namespace + "/" + bmcCredsSecret.Name,
+			SetHostError:     true,
+			HostErrorMessage: ErrMissingPassword.Error() + " with secret " + host.Spec.BMC.CredentialsName}
+	}
+
+	bmcCreds = &Credentials{
+		Host:       host,
+		SecretPath: bmcCredsSecret.Namespace + "/" + bmcCredsSecret.Name,
+		Username:   username,
+		Password:   password,
+		Secret:     bmcCredsSecret}
+
+	return bmcCreds, nil
 }

--- a/pkg/bmc/credentials_test.go
+++ b/pkg/bmc/credentials_test.go
@@ -1,48 +1,136 @@
 package bmc
 
 import (
+	goctx "context"
+	"encoding/base64"
 	"testing"
 
+	metalkubeapis "github.com/metalkube/baremetal-operator/pkg/apis"
+	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+const (
+	namespace         string = "test-namespace"
+	defaultSecretName string = "bmc-creds-valid"
 )
 
 func init() {
 	logf.SetLogger(logf.ZapLogger(true))
+	// Register our package types with the global scheme
+	metalkubeapis.AddToScheme(scheme.Scheme)
 }
 
+func newSecret(name, username, password string) *corev1.Secret {
+	data := make(map[string][]byte)
+	data["username"] = []byte(base64.StdEncoding.EncodeToString([]byte(username)))
+	data["password"] = []byte(base64.StdEncoding.EncodeToString([]byte(password)))
+
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			ResourceVersion: "1",
+		},
+		Data: data,
+	}
+
+	return secret
+}
+
+func newHost(name string, spec *metalkubev1alpha1.BareMetalHostSpec) *metalkubev1alpha1.BareMetalHost {
+	return &metalkubev1alpha1.BareMetalHost{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "BareMetalHost",
+			APIVersion: "metalkube.org/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: *spec,
+	}
+}
+
+func newDefaultHost(t *testing.T) *metalkubev1alpha1.BareMetalHost {
+	spec := &metalkubev1alpha1.BareMetalHostSpec{
+		BMC: metalkubev1alpha1.BMCDetails{
+			Address:         "ipmi://192.168.122.1:6233",
+			CredentialsName: defaultSecretName,
+		},
+	}
+	t.Logf("newDefaultHost(%s)", t.Name())
+	return newHost(t.Name(), spec)
+}
 func TestValidCredentials(t *testing.T) {
-	creds := Credentials{
-		Username: "username",
-		Password: "password",
+
+	host := newDefaultHost(t)
+
+	c := fakeclient.NewFakeClient()
+
+	// Create a BMC secret with proper username and password
+	c.Create(goctx.TODO(), newSecret(defaultSecretName, "User", "Pass"))
+
+	// Create and return a BMC Credentials object
+	_, err := NewCredentials(c, host)
+
+	if err != nil {
+		t.Fatalf("unexpected failure when building valid credentials object: %q", err)
 	}
-	valid, why := creds.AreValid()
-	if !valid {
-		t.Fatalf("got unexpected validation error: %q", why)
-	}
+
 }
 
 func TestMissingUser(t *testing.T) {
-	creds := Credentials{
-		Password: "password",
+
+	host := newDefaultHost(t)
+
+	c := fakeclient.NewFakeClient()
+
+	// Create a BMC secret with an empty user value
+	c.Create(goctx.TODO(), newSecret(defaultSecretName, "", "Pass"))
+
+	// Create and return a BMC Credentials object
+	_, err := NewCredentials(c, host)
+
+	if err == nil {
+		t.Fatalf("unexpected success when building invalid credentials object: %q", err)
 	}
-	valid, why := creds.AreValid()
-	if valid {
-		t.Fatal("got unexpected valid result")
-	}
-	if why != MissingUsernameMsg {
-		t.Fatalf("got unexpected reason for invalid creds: %q", why)
+
+	if err, ok := err.(*Error); ok {
+		if err.Err != ErrMissingUsername {
+			t.Fatalf("got unexpected reason for invalid creds: %q", err)
+		}
 	}
 }
 
 func TestMissingPassword(t *testing.T) {
-	creds := Credentials{
-		Username: "username",
+
+	host := newDefaultHost(t)
+
+	c := fakeclient.NewFakeClient()
+
+	// Create a BMC secret with an empty password value
+	c.Create(goctx.TODO(), newSecret(defaultSecretName, "User", ""))
+
+	// Create and return a BMC Credentials object
+	_, err := NewCredentials(c, host)
+
+	if err == nil {
+		t.Fatalf("unexpected success when building invalid credentials object: %q", err)
 	}
-	valid, why := creds.AreValid()
-	if valid {
-		t.Fatal("got unexpected valid result")
+
+	if err, ok := err.(*Error); ok {
+		if err.Err != ErrMissingPassword {
+			t.Fatalf("got unexpected reason for invalid creds: %q", err)
+		}
 	}
-	if why != MissingPasswordMsg {
-		t.Fatalf("got unexpected reason for invalid creds: %q", why)
-	}
+
 }


### PR DESCRIPTION
This introduces special handling when the BMC secret does not exist within Kubernetes so that a verbose traceback is not repeatedly logged.  Transient failures continue to be handled in the same way.

Closes: #126