### PR TITLE
Add script to run a local Ironic for development.

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -57,6 +57,17 @@ operator when launching it.
 operator-sdk up local --operator-flags "-test-mode"
 ```
 
+## Running a local instance of Ironic
+
+There is a script available that will run a set of containers locally using
+`podman` to stand up Ironic for development and testing.
+
+See `tools/run_local_ironic.sh`.
+
+Note that this script may need customizations to some of the `podman run`
+commands, to include environment variables that configure the containers for
+your environment.
+
 ## Using libvirt VMs with Ironic
 
 In order to use VMs as hosts, they need to be connected to [vbmc](https://docs.openstack.org/tripleo-docs/latest/install/environments/virtualbmc.html) and

--- a/tools/run_local_ironic.sh
+++ b/tools/run_local_ironic.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -ex
+
+IRONIC_IMAGE=${IRONIC_IMAGE:-"quay.io/metalkube/metalkube-ironic"}
+IRONIC_INSPECTOR_IMAGE=${IRONIC_INSPECTOR_IMAGE:-"quay.io/metalkube/metalkube-ironic-inspector"}
+IRONIC_DATA_DIR="$PWD/ironic"
+
+sudo podman pull $IRONIC_IMAGE
+sudo podman pull $IRONIC_INSPECTOR_IMAGE
+
+mkdir -p "$IRONIC_DATA_DIR/html/images"
+pushd $IRONIC_DATA_DIR/html/images
+
+# The images directory should contain images and an associated md5sum.
+#   - image.qcow2
+#   - image.qcow2.md5sum
+
+for name in ironic ironic-inspector dnsmasq httpd mariadb; do
+    sudo podman ps | grep -w "$name$" && sudo podman kill $name
+    sudo podman ps --all | grep -w "$name$" && sudo podman rm $name -f
+done
+
+# Remove existing pod
+if  sudo podman pod exists ironic-pod ; then
+    sudo podman pod rm ironic-pod -f
+fi
+
+# set password for mariadb
+mariadb_password=$(echo $(date;hostname)|sha256sum |cut -c-20)
+
+# Create pod
+sudo podman pod create -n ironic-pod
+
+# Start dnsmasq, http, mariadb, and ironic containers using same image
+
+# See this file for env vars you can set, like IP, DHCP_RANGE, INTERFACE
+# https://github.com/metalkube/metalkube-ironic/blob/master/rundnsmasq.sh
+sudo podman run -d --net host --privileged --name dnsmasq  --pod ironic-pod \
+     -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/rundnsmasq ${IRONIC_IMAGE}
+
+# For available env vars, see:
+# https://github.com/metalkube/metalkube-ironic/blob/master/runhttpd.sh
+sudo podman run -d --net host --privileged --name httpd --pod ironic-pod \
+     -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runhttpd ${IRONIC_IMAGE}
+
+# https://github.com/metalkube/metalkube-ironic/blob/master/runmariadb.sh
+sudo podman run -d --net host --privileged --name mariadb --pod ironic-pod \
+     -v $IRONIC_DATA_DIR:/shared --entrypoint /bin/runmariadb \
+     --env MARIADB_PASSWORD=$mariadb_password ${IRONIC_IMAGE}
+
+# See this file for additional env vars you may want to pass, like IP and INTERFACE
+# https://github.com/metalkube/metalkube-ironic/blob/master/runironic.sh
+sudo podman run -d --net host --privileged --name ironic --pod ironic-pod \
+     --env MARIADB_PASSWORD=$mariadb_password \
+     -v $IRONIC_DATA_DIR:/shared ${IRONIC_IMAGE}
+
+# Start Ironic Inspector
+sudo podman run -d --net host --privileged --name ironic-inspector --pod ironic-pod "${IRONIC_INSPECTOR_IMAGE}"


### PR DESCRIPTION
Ironic should eventually run in the baremetal-operator pod.  Right now
our sample pod yaml includes a sidecar proxy container that redirects
connections to the expected local Ironic to an Ironic running
elsewhere.

This script runs a set of containers for Ironic built from metalkube
repos.  It's useful for development environments until we move these
containers into the cluster properly.

This is copied from a repo of scripts where a group is workgin on
metalkube integration with OpenShift, but with the OpenShift specifics
removed and made more generally useful.

The original script was here:
https://github.com/openshift-metalkube/dev-scripts/blob/master/04_setup_ironic.sh