### PR TITLE
use the hardware profile to configure ironic to provision correctly

### DIFF
--- a/deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml
+++ b/deploy/crds/metalkube_v1alpha1_baremetalhost_crd.yaml
@@ -30,6 +30,10 @@ spec:
     description: Address of management controler
     name: BMC
     type: string
+  - JSONPath: .status.hardwareProfile
+    description: The type of hardware detected
+    name: Hardware Profile
+    type: string
   - JSONPath: .status.errorMessage
     description: Most recent error
     name: Error

--- a/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
+++ b/pkg/apis/metalkube/v1alpha1/baremetalhost_types.go
@@ -114,6 +114,11 @@ type BareMetalHostSpec struct {
 	// How do we connect to the BMC?
 	BMC BMCDetails `json:"bmc"`
 
+	// What is the name of the hardware profile for this host? It
+	// should only be necessary to set this when inspection cannot
+	// automatically determine the profile.
+	HardwareProfile string `json:"hardwareProfile"`
+
 	// Which MAC address will PXE boot? This is optional for some
 	// types, but required for libvirt VMs driven by vbmc.
 	BootMACAddress string `json:"bootMACAddress"`

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 
 	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
 	"github.com/metalkube/baremetal-operator/pkg/bmc"
+	"github.com/metalkube/baremetal-operator/pkg/hardware"
 	"github.com/metalkube/baremetal-operator/pkg/provisioner"
 	"github.com/metalkube/baremetal-operator/pkg/provisioner/demo"
 	"github.com/metalkube/baremetal-operator/pkg/provisioner/fixture"
@@ -255,7 +257,7 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 		actionName = metalkubev1alpha1.StateRegistering
 	case host.NeedsHardwareInspection():
 		actionName = metalkubev1alpha1.StateInspecting
-	case host.HardwareProfile() == "":
+	case host.NeedsHardwareProfile():
 		actionName = metalkubev1alpha1.StateMatchProfile
 	case host.NeedsProvisioning():
 		actionName = metalkubev1alpha1.StateProvisioning
@@ -487,8 +489,39 @@ func (r *ReconcileBareMetalHost) actionInspecting(prov provisioner.Provisioner, 
 
 func (r *ReconcileBareMetalHost) actionMatchProfile(prov provisioner.Provisioner, info *reconcileInfo) (result reconcile.Result, err error) {
 
-	// FIXME(dhellmann): Insert logic to match hardware profiles here.
-	hardwareProfile := "unknown"
+	var hardwareProfile string
+
+	info.log.Info("determining hardware profile")
+
+	// Start by looking for an override value from the user
+	if info.host.Spec.HardwareProfile != "" {
+		info.log.Info("using spec value for profile name",
+			"name", info.host.Spec.HardwareProfile)
+		hardwareProfile = info.host.Spec.HardwareProfile
+		_, err = hardware.GetProfile(hardwareProfile)
+		if err != nil {
+			info.log.Info("invalid hardware profile", "profile", hardwareProfile)
+			return result, err
+		}
+	}
+
+	// Now do a bit of matching.
+	//
+	// FIXME(dhellmann): Insert more robust logic to match
+	// hardware profiles here.
+	if hardwareProfile == "" {
+		if strings.HasPrefix(info.host.Spec.BMC.Address, "libvirt") {
+			hardwareProfile = "libvirt"
+			info.log.Info("determining from BMC address", "name", hardwareProfile)
+		}
+	}
+
+	// Now default to a value just in case there is no match
+	if hardwareProfile == "" {
+		hardwareProfile = hardware.DefaultProfileName
+		info.log.Info("using the default", "name", hardwareProfile)
+	}
+
 	if info.host.SetHardwareProfile(hardwareProfile) {
 		info.log.Info("updating hardware profile", "profile", hardwareProfile)
 		info.publishEvent("ProfileSet", fmt.Sprintf("Hardware profile set: %s", hardwareProfile))

--- a/pkg/hardware/profile.go
+++ b/pkg/hardware/profile.go
@@ -1,0 +1,88 @@
+package hardware
+
+import (
+	"fmt"
+)
+
+const (
+	// DefaultProfileName is the default hardware profile to use when
+	// no other profile matches.
+	DefaultProfileName string = "unknown"
+)
+
+// Profile holds the settings for a class of hardware.
+type Profile struct {
+	// Name holds the profile name
+	Name string
+
+	// RootDeviceHints holds the suggestions for placing the storage
+	// for the root filesystem.
+	RootDeviceHints RootDeviceHints
+
+	// RootGB is the size of the root volume in GB
+	RootGB int
+
+	// LocalGB is the size of something(?)
+	LocalGB int
+
+	// CPUArch is the architecture of the CPU.
+	CPUArch string
+}
+
+// RootDeviceHints holds the hints for specifying the storage location
+// for the root filesystem for the image.
+//
+// NOTE(dhellmann): Valid ironic hints are: "vendor,
+// wwn_vendor_extension, wwn_with_extension, by_path, serial, wwn,
+// size, rotational, name, hctl, model"
+type RootDeviceHints struct {
+	// A device name like "/dev/vda"
+	DeviceName string
+
+	// A SCSI bus address like 0:0:0:0
+	HCTL string
+}
+
+var profiles = make(map[string]Profile)
+
+func init() {
+	profiles[DefaultProfileName] = Profile{
+		Name: DefaultProfileName,
+		RootDeviceHints: RootDeviceHints{
+			DeviceName: "/dev/sda",
+		},
+		RootGB:  10,
+		LocalGB: 50,
+		CPUArch: "x86_64",
+	}
+
+	profiles["libvirt"] = Profile{
+		Name: "libvirt",
+		RootDeviceHints: RootDeviceHints{
+			DeviceName: "/dev/vda",
+		},
+		RootGB:  10,
+		LocalGB: 50,
+		CPUArch: "x86_64",
+	}
+
+	profiles["dell"] = Profile{
+		Name: "dell",
+		RootDeviceHints: RootDeviceHints{
+			HCTL: "0:0:0:0",
+		},
+		RootGB:  10,
+		LocalGB: 50,
+		CPUArch: "x86_64",
+	}
+
+}
+
+// GetProfile returns the named profile
+func GetProfile(name string) (Profile, error) {
+	profile, ok := profiles[name]
+	if !ok {
+		return Profile{}, fmt.Errorf("No hardware profile named %q", name)
+	}
+	return profile, nil
+}

--- a/pkg/provisioner/ironic/ironic_test.go
+++ b/pkg/provisioner/ironic/ironic_test.go
@@ -3,7 +3,13 @@ package ironic
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/gophercloud/gophercloud/openstack/baremetal/v1/nodes"
+
+	metalkubev1alpha1 "github.com/metalkube/baremetal-operator/pkg/apis/metalkube/v1alpha1"
+	"github.com/metalkube/baremetal-operator/pkg/bmc"
 )
 
 func init() {
@@ -27,5 +33,175 @@ func TestChecksumIsURLYes(t *testing.T) {
 	}
 	if err != nil {
 		t.Fail()
+	}
+}
+
+func TestGetUpdateOptsForNodeVirtual(t *testing.T) {
+	host := &metalkubev1alpha1.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhost",
+			Namespace: "myns",
+		},
+		Spec: metalkubev1alpha1.BareMetalHostSpec{
+			Image: &metalkubev1alpha1.Image{
+				URL: "not-empty",
+			},
+			Online: true,
+		},
+		Status: metalkubev1alpha1.BareMetalHostStatus{
+			HardwareProfile: "libvirt",
+			Provisioning: metalkubev1alpha1.ProvisionStatus{
+				ID: "provisioning-id",
+			},
+		},
+	}
+
+	eventPublisher := func(reason, message string) {}
+
+	prov, err := newProvisioner(host, bmc.Credentials{}, eventPublisher)
+	ironicNode := &nodes.Node{}
+
+	patches, err := prov.getUpdateOptsForNode(ironicNode, "checksum")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("patches: %v", patches)
+
+	var update nodes.UpdateOperation
+
+	expected := []struct {
+		Path  string      // the node property path
+		Key   string      // if value is a map, the key we care about
+		Value interface{} // the value being passed to ironic (or value associated with the key)
+	}{
+		{
+			Path:  "/instance_info/image_source",
+			Value: "not-empty",
+		},
+		{
+			Path:  "/instance_info/image_checksum",
+			Value: "checksum",
+		},
+		{
+			Path:  "/instance_uuid",
+			Value: "provisioning-id",
+		},
+		{
+			Path:  "/instance_info/root_gb",
+			Value: 10,
+		},
+		{
+			Path:  "/instance_info/root_device",
+			Value: "/dev/vda",
+			Key:   "name",
+		},
+		{
+			Path:  "/properties/cpu_arch",
+			Value: "x86_64",
+		},
+		{
+			Path:  "/properties/local_gb",
+			Value: 50,
+		},
+	}
+
+	for i, e := range expected {
+		update = patches[i].(nodes.UpdateOperation)
+		if e.Key != "" {
+			m := update.Value.(map[string]string)
+			if m[e.Key] != e.Value {
+				t.Errorf("expected %s=%q got %s=%q", e.Path, e.Value, update.Path, update.Value)
+			}
+		} else {
+			if update.Value != e.Value {
+				t.Errorf("expected %s=%q got %s=%q", e.Path, e.Value, update.Path, update.Value)
+			}
+		}
+	}
+}
+
+func TestGetUpdateOptsForNodeDell(t *testing.T) {
+	host := &metalkubev1alpha1.BareMetalHost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myhost",
+			Namespace: "myns",
+		},
+		Spec: metalkubev1alpha1.BareMetalHostSpec{
+			Image: &metalkubev1alpha1.Image{
+				URL: "not-empty",
+			},
+			Online: true,
+		},
+		Status: metalkubev1alpha1.BareMetalHostStatus{
+			HardwareProfile: "dell",
+			Provisioning: metalkubev1alpha1.ProvisionStatus{
+				ID: "provisioning-id",
+			},
+		},
+	}
+
+	eventPublisher := func(reason, message string) {}
+
+	prov, err := newProvisioner(host, bmc.Credentials{}, eventPublisher)
+	ironicNode := &nodes.Node{}
+
+	patches, err := prov.getUpdateOptsForNode(ironicNode, "checksum")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("patches: %v", patches)
+
+	var update nodes.UpdateOperation
+
+	expected := []struct {
+		Path  string      // the node property path
+		Key   string      // if value is a map, the key we care about
+		Value interface{} // the value being passed to ironic (or value associated with the key)
+	}{
+		{
+			Path:  "/instance_info/image_source",
+			Value: "not-empty",
+		},
+		{
+			Path:  "/instance_info/image_checksum",
+			Value: "checksum",
+		},
+		{
+			Path:  "/instance_uuid",
+			Value: "provisioning-id",
+		},
+		{
+			Path:  "/instance_info/root_gb",
+			Value: 10,
+		},
+		{
+			Path:  "/instance_info/root_device",
+			Value: "0:0:0:0",
+			Key:   "hctl",
+		},
+		{
+			Path:  "/properties/cpu_arch",
+			Value: "x86_64",
+		},
+		{
+			Path:  "/properties/local_gb",
+			Value: 50,
+		},
+	}
+
+	for i, e := range expected {
+		update = patches[i].(nodes.UpdateOperation)
+		if e.Key != "" {
+			m := update.Value.(map[string]string)
+			if m[e.Key] != e.Value {
+				t.Errorf("expected %s=%q got %s=%q", e.Path, e.Value, update.Path, update.Value)
+			}
+		} else {
+			if update.Value != e.Value {
+				t.Errorf("expected %s=%q got %s=%q", e.Path, e.Value, update.Path, update.Value)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Add some temporarily hacky logic to guess the hardware profile so we
can get a root device. The real profile will eventually come from
matching inspected inventory, when we implement that. In the mean
time, use the BMC type to detect virt vs. physical, and provide a
field in the host spec to override the guess of a profile if we get it
wrong.

Also rewrite the logic for setting individual host and image
properties so they are all checked and added or updated as required.