### PR TITLE
Align make-bm-worker with dev-script's version

### DIFF
--- a/cmd/make-bm-worker/main.go
+++ b/cmd/make-bm-worker/main.go
@@ -29,14 +29,22 @@ spec:
   bmc:
     address: {{ .BMCAddress }}
     credentialsName: {{ .Name }}-bmc-secret
+{{- if .WithMachine }}
+  machineRef:
+    name: {{ .Machine }}
+    namespace: {{ .MachineNamespace }}
+{{- end }}
 `
 
 // TemplateArgs holds the arguments to pass to the template.
 type TemplateArgs struct {
-	Name            string
-	BMCAddress      string
-	EncodedUsername string
-	EncodedPassword string
+	Name             string
+	BMCAddress       string
+	EncodedUsername  string
+	EncodedPassword  string
+	WithMachine      bool
+	Machine          string
+	MachineNamespace string
 }
 
 func encodeToSecret(input string) string {
@@ -48,6 +56,10 @@ func main() {
 	var password = flag.String("password", "", "password for BMC")
 	var bmcAddress = flag.String("address", "", "address URL for BMC")
 	var verbose = flag.Bool("v", false, "turn on verbose output")
+	var machine = flag.String(
+		"machine", "", "specify name of a related, existing, machine to link")
+	var machineNamespace = flag.String(
+		"machine-namespace", "", "specify namespace of a related, existing, machine to link")
 
 	flag.Parse()
 
@@ -70,10 +82,15 @@ func main() {
 	}
 
 	args := TemplateArgs{
-		Name:            strings.Replace(hostName, "_", "-", -1),
-		BMCAddress:      *bmcAddress,
-		EncodedUsername: encodeToSecret(*username),
-		EncodedPassword: encodeToSecret(*password),
+		Name:             strings.Replace(hostName, "_", "-", -1),
+		BMCAddress:       *bmcAddress,
+		EncodedUsername:  encodeToSecret(*username),
+		EncodedPassword:  encodeToSecret(*password),
+		Machine:          strings.TrimSpace(*machine),
+		MachineNamespace: strings.TrimSpace(*machineNamespace),
+	}
+	if args.Machine != "" {
+		args.WithMachine = true
 	}
 	if *verbose {
 		fmt.Fprintf(os.Stderr, "%v", args)


### PR DESCRIPTION
Commit https://github.com/openshift-metalkube/dev-scripts/commit/470a7bcbdc76db9ac7e9cf4086db79b418215fcf#diff-6aaa4e12b6fddc1b93b9ee994b50a49b introduced
ability to register both master and worker nodes.
This change brings in custom changes to make-bm-worker utility
to the BMO's repo.