### PR TITLE
Refactor Reconciler BMC Error Handling

### DIFF
--- a/pkg/bmc/access.go
+++ b/pkg/bmc/access.go
@@ -1,7 +1,6 @@
 package bmc
 
 import (
-	"fmt"
 	"net"
 	"net/url"
 	"strings"
@@ -32,18 +31,6 @@ type AccessDetails interface {
 	// expected to add any other information that might be needed
 	// (such as the kernel and ramdisk locations).
 	DriverInfo(bmcCreds Credentials) map[string]interface{}
-}
-
-// UnknownBMCTypeError is returned when the provided BMC address cannot be
-// mapped to a driver.
-type UnknownBMCTypeError struct {
-	address string
-	bmcType string
-}
-
-func (e UnknownBMCTypeError) Error() string {
-	return fmt.Sprintf("Unknown BMC type '%s' for address %s",
-		e.bmcType, e.address)
 }
 
 func getTypeHostPort(address string) (bmcType, host, port, path string, err error) {

--- a/pkg/bmc/credentials.go
+++ b/pkg/bmc/credentials.go
@@ -1,23 +1,5 @@
 package bmc
 
-const (
-	// MissingCredentialsMsg is returned as a validation failure
-	// reason when there are no credentials at all.
-	MissingCredentialsMsg string = "Missing BMC connection details: Credentials"
-
-	// MissingAddressMsg is returned as a validation failure
-	// reason when there is no address for the BMC.
-	MissingAddressMsg string = "Missing BMC connection details: Address"
-
-	// MissingUsernameMsg is returned as a validation failure reason
-	// when the credentials do not include a "username" field.
-	MissingUsernameMsg string = "Missing BMC connection details: 'username' in credentials"
-
-	// MissingPasswordMsg is returned as a validation failure reason
-	// when the credentials do not include a "password" field.
-	MissingPasswordMsg string = "Missing BMC connection details: 'password' in credentials"
-)
-
 // Credentials holds the information for authenticating with the BMC.
 type Credentials struct {
 	Username string
@@ -26,12 +8,12 @@ type Credentials struct {
 
 // AreValid returns a boolean indicating whether the credentials are
 // valid, and if false a string explaining why not.
-func (creds Credentials) AreValid() (bool, string) {
+func (creds Credentials) AreValid() (bool, error) {
 	if creds.Username == "" {
-		return false, MissingUsernameMsg
+		return false, &ValidationError{message: "Missing BMC connection detail 'username' in credentials"}
 	}
 	if creds.Password == "" {
-		return false, MissingPasswordMsg
+		return false, &ValidationError{message: "Missing BMC connection details 'password' in credentials"}
 	}
-	return true, ""
+	return true, nil
 }

--- a/pkg/bmc/credentials.go
+++ b/pkg/bmc/credentials.go
@@ -6,14 +6,13 @@ type Credentials struct {
 	Password string
 }
 
-// AreValid returns a boolean indicating whether the credentials are
-// valid, and if false a string explaining why not.
-func (creds Credentials) AreValid() (bool, error) {
+// Validate returns an error if the credentials are invalid
+func (creds Credentials) Validate() error {
 	if creds.Username == "" {
-		return false, &ValidationError{message: "Missing BMC connection detail 'username' in credentials"}
+		return &CredentialsValidationError{message: "Missing BMC connection detail 'username' in credentials"}
 	}
 	if creds.Password == "" {
-		return false, &ValidationError{message: "Missing BMC connection details 'password' in credentials"}
+		return &CredentialsValidationError{message: "Missing BMC connection details 'password' in credentials"}
 	}
-	return true, nil
+	return nil
 }

--- a/pkg/bmc/credentials_test.go
+++ b/pkg/bmc/credentials_test.go
@@ -15,9 +15,9 @@ func TestValidCredentials(t *testing.T) {
 		Username: "username",
 		Password: "password",
 	}
-	valid, why := creds.AreValid()
+	valid, err := creds.AreValid()
 	if !valid {
-		t.Fatalf("got unexpected validation error: %q", why)
+		t.Fatalf("got unexpected validation error: %q", err)
 	}
 }
 
@@ -25,12 +25,9 @@ func TestMissingUser(t *testing.T) {
 	creds := Credentials{
 		Password: "password",
 	}
-	valid, why := creds.AreValid()
-	if valid {
+	valid, err := creds.AreValid()
+	if valid || err == nil {
 		t.Fatal("got unexpected valid result")
-	}
-	if why != MissingUsernameMsg {
-		t.Fatalf("got unexpected reason for invalid creds: %q", why)
 	}
 }
 
@@ -38,11 +35,8 @@ func TestMissingPassword(t *testing.T) {
 	creds := Credentials{
 		Username: "username",
 	}
-	valid, why := creds.AreValid()
-	if valid {
+	valid, err := creds.AreValid()
+	if valid || err == nil {
 		t.Fatal("got unexpected valid result")
-	}
-	if why != MissingPasswordMsg {
-		t.Fatalf("got unexpected reason for invalid creds: %q", why)
 	}
 }

--- a/pkg/bmc/credentials_test.go
+++ b/pkg/bmc/credentials_test.go
@@ -15,8 +15,8 @@ func TestValidCredentials(t *testing.T) {
 		Username: "username",
 		Password: "password",
 	}
-	valid, err := creds.AreValid()
-	if !valid {
+	err := creds.Validate()
+	if err != nil {
 		t.Fatalf("got unexpected validation error: %q", err)
 	}
 }
@@ -25,8 +25,8 @@ func TestMissingUser(t *testing.T) {
 	creds := Credentials{
 		Password: "password",
 	}
-	valid, err := creds.AreValid()
-	if valid || err == nil {
+	err := creds.Validate()
+	if err == nil {
 		t.Fatal("got unexpected valid result")
 	}
 }
@@ -35,8 +35,8 @@ func TestMissingPassword(t *testing.T) {
 	creds := Credentials{
 		Username: "username",
 	}
-	valid, err := creds.AreValid()
-	if valid || err == nil {
+	err := creds.Validate()
+	if err == nil {
 		t.Fatal("got unexpected valid result")
 	}
 }

--- a/pkg/bmc/errors.go
+++ b/pkg/bmc/errors.go
@@ -1,0 +1,28 @@
+package bmc
+
+import (
+	"fmt"
+)
+
+// UnknownBMCTypeError is returned when the provided BMC address cannot be
+// mapped to a driver.
+type UnknownBMCTypeError struct {
+	address string
+	bmcType string
+}
+
+func (e UnknownBMCTypeError) Error() string {
+	return fmt.Sprintf("Unknown BMC type '%s' for address %s",
+		e.bmcType, e.address)
+}
+
+// ValidationError is returned when the provided BMC credentials
+// are invalid (e.g. null)
+type ValidationError struct {
+	message string
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("Validation error with BMC credentials: %s",
+		e.message)
+}

--- a/pkg/bmc/errors.go
+++ b/pkg/bmc/errors.go
@@ -16,13 +16,13 @@ func (e UnknownBMCTypeError) Error() string {
 		e.bmcType, e.address)
 }
 
-// ValidationError is returned when the provided BMC credentials
+// CredentialsValidationError is returned when the provided BMC credentials
 // are invalid (e.g. null)
-type ValidationError struct {
+type CredentialsValidationError struct {
 	message string
 }
 
-func (e ValidationError) Error() string {
+func (e CredentialsValidationError) Error() string {
 	return fmt.Sprintf("Validation error with BMC credentials: %s",
 		e.message)
 }

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -732,7 +732,7 @@ func (r *ReconcileBareMetalHost) getBMCSecretAndSetOwner(request reconcile.Reque
 	}
 
 	// Make sure the secret has the correct owner as soon as we can.
-	// This can return an SaveBMCCredentialsSecretOwnerError
+	// This can return an SaveBMCSecretOwnerError
 	// which isn't handled causing us to immediately try again
 	// which seems fine as we expect this to be a transient failure
 	err = r.setBMCCredentialsSecretOwner(request, host, bmcCredsSecret)
@@ -792,11 +792,11 @@ func (r *ReconcileBareMetalHost) setBMCCredentialsSecretOwner(request reconcile.
 	reqLogger.Info("updating owner of secret")
 	err = controllerutil.SetControllerReference(host, secret, r.scheme)
 	if err != nil {
-		return &SaveBMCCredentialsSecretOwnerError{message: fmt.Sprintf("cannot set owner: %q", err.Error())}
+		return &SaveBMCSecretOwnerError{message: fmt.Sprintf("cannot set owner: %q", err.Error())}
 	}
 	err = r.client.Update(context.TODO(), secret)
 	if err != nil {
-		return &SaveBMCCredentialsSecretOwnerError{message: fmt.Sprintf("cannot save owner: %q", err.Error())}
+		return &SaveBMCSecretOwnerError{message: fmt.Sprintf("cannot save owner: %q", err.Error())}
 	}
 	return nil
 }

--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -198,54 +198,56 @@ func (r *ReconcileBareMetalHost) Reconcile(request reconcile.Request) (result re
 		return result, err
 	}
 
-	// Check for a "discovered" host vs. one that we have all the info for.
-	if host.Spec.BMC.Address == "" {
-		reqLogger.Info(bmc.MissingAddressMsg)
-		dirty := host.SetOperationalStatus(metalkubev1alpha1.OperationalStatusDiscovered)
-		if dirty {
-			err = r.saveStatus(host)
-			if err != nil {
+	// Retrieve the BMC details from the host spec and validate host
+	// BMC details and build the credentials for talking to the
+	// management controller.
+	bmcCreds, bmcCredsSecret, err := r.buildAndValidateBMCCredentials(request, host)
+	if err != nil {
+		switch err.(type) {
+
+		// We key on invalid bmc address and secret references as a trigger
+		// the host needs to be put into a discovered status and requeue it for
+		// later.  We do set an error message (but not an error state) on the host
+		// so we can understand what we may be waiting on.
+		case *InvalidBMCAddressError, *InvalidBMCSecretError:
+			dirty := host.SetOperationalStatus(metalkubev1alpha1.OperationalStatusDiscovered)
+			if dirty {
+				// Set the host error message directly
+				// as we cannot use SetErrorCondition which
+				// overwrites our discovered state
+				host.Status.ErrorMessage = err.Error()
+				saveErr := r.saveStatus(host)
+				if saveErr != nil {
+					return reconcile.Result{Requeue: true}, saveErr
+				}
 				// Only publish the event if we do not have an error
 				// after saving so that we only publish one time.
 				r.publishEvent(request,
-					host.NewEvent("Discovered", "Discovered host without BMC address"))
+					host.NewEvent("Discovered", fmt.Sprintf("Discovered host with unusable BMC details: %s", err.Error())))
 			}
-			// Without the address we can't do any more so we return here
-			// without checking for an error.
-			return reconcile.Result{Requeue: true}, err
-		}
-		reqLogger.Info("nothing to do for discovered host without BMC address")
-		return reconcile.Result{}, nil
-	}
-	if host.Spec.BMC.CredentialsName == "" {
-		reqLogger.Info(bmc.MissingCredentialsMsg)
-		dirty := host.SetOperationalStatus(metalkubev1alpha1.OperationalStatusDiscovered)
-		if dirty {
-			err = r.saveStatus(host)
-			if err != nil {
-				// Only publish the event if we do not have an error
-				// after saving so that we only publish one time.
-				r.publishEvent(request,
-					host.NewEvent("Discovered", "Discovered host without BMC credentials"))
+			// This avoids tracebacks on these "expected" missing values
+			return reconcile.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
+		// In the case of a non-null empty secret reference that has invalid data
+		// or non-null and invalid BMC addresses, we set the host into an error state
+		// and requeue it for evaluation later
+		case *bmc.ValidationError, *bmc.UnknownBMCTypeError:
+			saveErr := r.setErrorCondition(request, host, err.Error())
+			if saveErr != nil {
+				return reconcile.Result{Requeue: true}, saveErr
 			}
-			// Without any credentials we can't do any more so we return
-			// here without checking for an error.
-			return reconcile.Result{Requeue: true}, err
+			// Only publish the event if we do not have an error
+			// after saving so that we only publish one time.
+			r.publishEvent(request, host.NewEvent("BMCCredentialError", err.Error()))
+			return reconcile.Result{Requeue: true, RequeueAfter: hostErrorRetryDelay}, nil
+		default:
+			return reconcile.Result{}, errors.Wrap(err, "An unhandled failure occurred validating the BMC secret")
 		}
-		reqLogger.Info("nothing to do for discovered host without BMC credentials")
-		return reconcile.Result{}, nil
 	}
 
-	// Load the credentials for talking to the management controller.
-	bmcCreds, bmcCredsSecret, err := r.getValidBMCCredentials(request, host)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "BMC credentials are invalid")
-	}
-	if bmcCreds == nil {
-		// We do not have valid credentials, but did not encounter a
-		// retriable error in determining that. Reconciliation is
-		// complete until something about the secrets change.
-		return reconcile.Result{}, nil
+	// Make sure the secret has the correct owner.
+	if err = r.setBMCCredentialsSecretOwner(request, host, bmcCredsSecret); err != nil {
+		return reconcile.Result{}, errors.Wrap(err,
+			"failed to update owner of credentials secret")
 	}
 
 	// Pick the action to perform
@@ -371,11 +373,11 @@ func (r *ReconcileBareMetalHost) deleteHost(request reconcile.Request, host *met
 		return reconcile.Result{}, nil
 	}
 
-	bmcCreds, _, err := r.getValidBMCCredentials(request, host)
-	// We ignore the error, because we are deleting this host anyway.
-	if bmcCreds == nil {
-		// There are no valid credentials, so create an empty
-		// credentials object to give to the provisioner.
+	// Retrieve the BMC secret from Kubernetes for this host and
+	// try and build credentials.  If we fail, resort to an empty
+	// credentials object to give the provisioner
+	bmcCreds, _, err := r.buildAndValidateBMCCredentials(request, host)
+	if err != nil || bmcCreds == nil {
 		bmcCreds = &bmc.Credentials{}
 	}
 
@@ -706,50 +708,62 @@ func (r *ReconcileBareMetalHost) setErrorCondition(request reconcile.Request, ho
 	return nil
 }
 
-// Make sure the credentials for the management controller look
-// right. This does not actually try to use the credentials.
-func (r *ReconcileBareMetalHost) getValidBMCCredentials(request reconcile.Request, host *metalkubev1alpha1.BareMetalHost) (bmcCreds *bmc.Credentials, bmcCredsSecret *corev1.Secret, err error) {
-	reqLogger := log.WithValues("Request.Namespace",
-		request.Namespace, "Request.Name", request.Name)
+// Retrieve the secret containing the credentials for talking to the BMC.
+func (r *ReconcileBareMetalHost) getBMCKubernetesSecret(request reconcile.Request, host *metalkubev1alpha1.BareMetalHost) (bmcCredsSecret *corev1.Secret, err error) {
 
-	// Load the secret containing the credentials for talking to the
-	// BMC. This assumes we have a reference to the secret, otherwise
-	// Reconcile() should not have let us be called.
+	if host.Spec.BMC.CredentialsName == "" {
+		return nil, &InvalidBMCSecretError{message: "The BMC secret reference is empty"}
+	}
 	secretKey := host.CredentialsKey()
 	bmcCredsSecret = &corev1.Secret{}
 	err = r.client.Get(context.TODO(), secretKey, bmcCredsSecret)
 	if err != nil {
-		return nil, nil, errors.Wrap(err,
-			"failed to fetch BMC credentials from secret reference")
+		if k8serrors.IsNotFound(err) {
+			return nil, &InvalidBMCSecretError{message: fmt.Sprintf("The BMC secret %s does not exist", secretKey)}
+		}
+		return nil, err
 	}
+	return bmcCredsSecret, nil
+
+}
+
+// Make sure the credentials for the management controller look
+// right and manufacture bmc.Credentials.  This does not actually try
+// to use the credentials.
+func (r *ReconcileBareMetalHost) buildAndValidateBMCCredentials(request reconcile.Request, host *metalkubev1alpha1.BareMetalHost) (bmcCreds *bmc.Credentials, bmcCredsSecret *corev1.Secret, err error) {
+
+	// Retrieve the BMC secret from Kubernetes for this host
+	bmcCredsSecret, err = r.getBMCKubernetesSecret(request, host)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Check for a "discovered" host vs. one that we have all the info for
+	// and find empty Address or CredentialsName fields
+	if host.Spec.BMC.Address == "" {
+		return nil, nil, &InvalidBMCAddressError{message: "Missing BMC connection detail 'Address'"}
+	}
+
+	// Ensure NewAccessDetails, which does more indepth checking of the address field
+	// doesn't raise an UnknownBMCTypeError so we can catch it early
+	_, err = bmc.NewAccessDetails(host.Spec.BMC.Address)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	bmcCreds = &bmc.Credentials{
 		Username: string(bmcCredsSecret.Data["username"]),
 		Password: string(bmcCredsSecret.Data["password"]),
 	}
 
 	// Verify that the secret contains the expected info.
-	if validCreds, reason := bmcCreds.AreValid(); !validCreds {
-		reqLogger.Info("invalid BMC Credentials", "reason", reason)
-		err := r.setErrorCondition(request, host, reason)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to set error condition")
-		}
-
-		// Only publish the event if we do not have an error
-		// after saving so that we only publish one time.
-		r.publishEvent(request, host.NewEvent("BMCCredentialError", reason))
-
-		// This is not an error we can retry from, so stop reconciling.
-		return nil, nil, nil
-	}
-
-	// Make sure the secret has the correct owner.
-	if err = r.setBMCCredentialsSecretOwner(request, host, bmcCredsSecret); err != nil {
-		return nil, nil, errors.Wrap(err,
-			"failed to update owner of credentials secret")
+	_, err = bmcCreds.AreValid()
+	if err != nil {
+		return nil, bmcCredsSecret, err
 	}
 
 	return bmcCreds, bmcCredsSecret, nil
+
 }
 
 func (r *ReconcileBareMetalHost) setBMCCredentialsSecretOwner(request reconcile.Request, host *metalkubev1alpha1.BareMetalHost, secret *corev1.Secret) (err error) {

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -359,6 +359,27 @@ func TestMissingBMCParameters(t *testing.T) {
 		})
 	r = newTestReconciler(noPassword, secretNoPassword)
 	waitForError(t, r, noPassword)
+
+	secretOk := newSecret("bmc-creds-no-pass", "User", "Pass")
+	noAddress := newHost("missing-bmc-address",
+		&metalkubev1alpha1.BareMetalHostSpec{
+			BMC: metalkubev1alpha1.BMCDetails{
+				Address:         "",
+				CredentialsName: "bmc-creds-no-pass",
+			},
+		})
+	r = newTestReconciler(noAddress, secretOk)
+	waitForError(t, r, noAddress)
+
+	noSecretRef := newHost("missing-bmc-address",
+		&metalkubev1alpha1.BareMetalHostSpec{
+			BMC: metalkubev1alpha1.BMCDetails{
+				Address:         "ipmi://192.168.122.1:6233",
+				CredentialsName: "",
+			},
+		})
+	r = newTestReconciler(noSecretRef, secretOk)
+	waitForError(t, r, noSecretRef)
 }
 
 // TestFixSecret ensures that when the secret for a host is updated to

--- a/pkg/controller/baremetalhost/baremetalhost_controller_test.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller_test.go
@@ -338,6 +338,8 @@ func TestDiscoveredHost(t *testing.T) {
 // of the required BMC settings is put into an error state.
 func TestMissingBMCParameters(t *testing.T) {
 
+	// test bmc data populated with a secret that itself contains
+	// invalid or null parameters
 	secretNoUser := newSecret("bmc-creds-no-user", "", "Pass")
 	noUsername := newHost("missing-bmc-username",
 		&metalkubev1alpha1.BareMetalHostSpec{
@@ -360,26 +362,53 @@ func TestMissingBMCParameters(t *testing.T) {
 	r = newTestReconciler(noPassword, secretNoPassword)
 	waitForError(t, r, noPassword)
 
-	secretOk := newSecret("bmc-creds-no-pass", "User", "Pass")
+	// test we set an error message when the address
+	// is malformed - bmc access tests do more exhaustive
+	// type checking tests
+	secretOk := newSecret("bmc-creds-ok", "User", "Pass")
+	invalidAddress := newHost("invalid-bmc-address",
+		&metalkubev1alpha1.BareMetalHostSpec{
+			BMC: metalkubev1alpha1.BMCDetails{
+				Address:         "unknown://notAvalidIPMIURL",
+				CredentialsName: "bmc-creds-ok",
+			},
+		})
+	r = newTestReconciler(invalidAddress, secretOk)
+	waitForError(t, r, invalidAddress)
+
+	// test we set an error message when BMCDetails are missing
+	secretOk = newSecret("bmc-creds-ok", "User", "Pass")
 	noAddress := newHost("missing-bmc-address",
 		&metalkubev1alpha1.BareMetalHostSpec{
 			BMC: metalkubev1alpha1.BMCDetails{
 				Address:         "",
-				CredentialsName: "bmc-creds-no-pass",
+				CredentialsName: "bmc-creds-ok",
 			},
 		})
 	r = newTestReconciler(noAddress, secretOk)
 	waitForError(t, r, noAddress)
 
-	noSecretRef := newHost("missing-bmc-address",
+	noSecretRef := newHost("missing-bmc-credentials-ref",
 		&metalkubev1alpha1.BareMetalHostSpec{
 			BMC: metalkubev1alpha1.BMCDetails{
 				Address:         "ipmi://192.168.122.1:6233",
 				CredentialsName: "",
 			},
 		})
-	r = newTestReconciler(noSecretRef, secretOk)
+	r = newTestReconciler(noSecretRef)
 	waitForError(t, r, noSecretRef)
+
+	// test we set an error message when the CredentialsName
+	// defined does not exist in kubernetes
+	NonExistentSecretRef := newHost("non-existent-bmc-secret-ref",
+		&metalkubev1alpha1.BareMetalHostSpec{
+			BMC: metalkubev1alpha1.BMCDetails{
+				Address:         "ipmi://192.168.122.1:6233",
+				CredentialsName: "this-secret-does-not-exist",
+			},
+		})
+	r = newTestReconciler(NonExistentSecretRef)
+	waitForError(t, r, NonExistentSecretRef)
 }
 
 // TestFixSecret ensures that when the secret for a host is updated to

--- a/pkg/controller/baremetalhost/errors.go
+++ b/pkg/controller/baremetalhost/errors.go
@@ -5,7 +5,7 @@ import (
 )
 
 // EmptyBMCAddressError is returned when the BMC address field
-// for a host is invalid or empty
+// for a host is empty
 type EmptyBMCAddressError struct {
 	message string
 }

--- a/pkg/controller/baremetalhost/errors.go
+++ b/pkg/controller/baremetalhost/errors.go
@@ -36,3 +36,14 @@ func (e ResolveBMCSecretRefError) Error() string {
 	return fmt.Sprintf("BMC CredentialsName secret doesn't exist %s",
 		e.message)
 }
+
+// SaveBMCCredentialsSecretOwnerError is returned when we
+// fail to set the owner of a secret
+type SaveBMCCredentialsSecretOwnerError struct {
+	message string
+}
+
+func (e SaveBMCCredentialsSecretOwnerError) Error() string {
+	return fmt.Sprintf("Failed to set owner of BMC secret %s",
+		e.message)
+}

--- a/pkg/controller/baremetalhost/errors.go
+++ b/pkg/controller/baremetalhost/errors.go
@@ -1,0 +1,27 @@
+package baremetalhost
+
+import (
+	"fmt"
+)
+
+// InvalidBMCAddressError is returned when the BMC address field
+// for a host is invalid or empty
+type InvalidBMCAddressError struct {
+	message string
+}
+
+func (e InvalidBMCAddressError) Error() string {
+	return fmt.Sprintf("Invalid BMC address %s",
+		e.message)
+}
+
+// InvalidBMCSecretError is returned when the BMC secret
+// for a host is invalid or empty
+type InvalidBMCSecretError struct {
+	message string
+}
+
+func (e InvalidBMCSecretError) Error() string {
+	return fmt.Sprintf("Invalid BMC Secret %s",
+		e.message)
+}

--- a/pkg/controller/baremetalhost/errors.go
+++ b/pkg/controller/baremetalhost/errors.go
@@ -4,24 +4,35 @@ import (
 	"fmt"
 )
 
-// InvalidBMCAddressError is returned when the BMC address field
+// EmptyBMCAddressError is returned when the BMC address field
 // for a host is invalid or empty
-type InvalidBMCAddressError struct {
+type EmptyBMCAddressError struct {
 	message string
 }
 
-func (e InvalidBMCAddressError) Error() string {
-	return fmt.Sprintf("Invalid BMC address %s",
+func (e EmptyBMCAddressError) Error() string {
+	return fmt.Sprintf("Empty BMC address %s",
 		e.message)
 }
 
-// InvalidBMCSecretError is returned when the BMC secret
-// for a host is invalid or empty
-type InvalidBMCSecretError struct {
+// EmptyBMCSecretError is returned when the BMC secret
+// for a host is empty
+type EmptyBMCSecretError struct {
 	message string
 }
 
-func (e InvalidBMCSecretError) Error() string {
-	return fmt.Sprintf("Invalid BMC Secret %s",
+func (e EmptyBMCSecretError) Error() string {
+	return fmt.Sprintf("No BMC CredentialsName defined %s",
+		e.message)
+}
+
+// ResolveBMCSecretRefError is returned when the BMC secret
+// for a host is defined but cannot be found
+type ResolveBMCSecretRefError struct {
+	message string
+}
+
+func (e ResolveBMCSecretRefError) Error() string {
+	return fmt.Sprintf("BMC CredentialsName secret doesn't exist %s",
 		e.message)
 }

--- a/pkg/controller/baremetalhost/errors.go
+++ b/pkg/controller/baremetalhost/errors.go
@@ -37,13 +37,13 @@ func (e ResolveBMCSecretRefError) Error() string {
 		e.message)
 }
 
-// SaveBMCCredentialsSecretOwnerError is returned when we
+// SaveBMCSecretOwnerError is returned when we
 // fail to set the owner of a secret
-type SaveBMCCredentialsSecretOwnerError struct {
+type SaveBMCSecretOwnerError struct {
 	message string
 }
 
-func (e SaveBMCCredentialsSecretOwnerError) Error() string {
+func (e SaveBMCSecretOwnerError) Error() string {
 	return fmt.Sprintf("Failed to set owner of BMC secret %s",
 		e.message)
 }


### PR DESCRIPTION
This pull request refactors the error handling for many `Reconcile` BMC operations and introduces a few strongly typed errors for both the `bmc` and the `baremetalhost` packages.  I hope this type of error typing is continued.  It is heavily based on the feedback in the now closed [PR#135](https://github.com/metalkube/baremetal-operator/pull/135) and attempts to incorporate the feedback there and I hopefully satisfies many of the requests.

This also closes [Issue#126](https://github.com/metalkube/baremetal-operator/issues/126)  as missing secrets should no longer result in tracebacks.

Closes: #126 