### PR TITLE
make registration error a steady state

### DIFF
--- a/pkg/controller/baremetalhost/baremetalhost_controller.go
+++ b/pkg/controller/baremetalhost/baremetalhost_controller.go
@@ -428,9 +428,10 @@ func (r *ReconcileBareMetalHost) actionRegistering(prov provisioner.Provisioner,
 
 	if provResult.ErrorMessage != "" {
 		info.host.Status.Provisioning.State = metalkubev1alpha1.StateRegistrationError
-		info.host.SetErrorMessage(provResult.ErrorMessage)
-		info.publishEvent("RegistrationError", provResult.ErrorMessage)
-		result.Requeue = true
+		if info.host.SetErrorMessage(provResult.ErrorMessage) {
+			info.publishEvent("RegistrationError", provResult.ErrorMessage)
+			result.Requeue = true
+		}
 		return result, nil
 	}
 


### PR DESCRIPTION
If a host fails registration with the same error message a second
time, that means we have reconciled it twice with the same data and it
still does not work. Rather than keep trying, which toggles the host
between "registering" and "registration error" indefinitely, leave the
host in the "registration error" state.