### PR TITLE
remove quotes from env vars in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ DEBUG = --debug
 SETUP = --no-setup
 
 # Set some variables the operator expects to have in order to work
-export OPERATOR_NAME="baremetal-operator"
-export DEPLOY_KERNEL_URL="http://172.22.0.1/images/ironic-python-agent.kernel"
-export DEPLOY_RAMDISK_URL="http://172.22.0.1/images/ironic-python-agent.initramfs"
-export IRONIC_ENDPOINT="http://localhost:6385/v1/"
+export OPERATOR_NAME=baremetal-operator
+export DEPLOY_KERNEL_URL=http://172.22.0.1/images/ironic-python-agent.kernel
+export DEPLOY_RAMDISK_URL=http://172.22.0.1/images/ironic-python-agent.initramfs
+export IRONIC_ENDPOINT=http://localhost:6385/v1/
 
 .PHONY: help
 help:

--- a/pkg/provisioner/ironic/ironic.go
+++ b/pkg/provisioner/ironic/ironic.go
@@ -82,6 +82,11 @@ type ironicProvisioner struct {
 // A private function to construct an ironicProvisioner (rather than a
 // Provisioner interface) in a consistent way for tests.
 func newProvisioner(host *metalkubev1alpha1.BareMetalHost, bmcCreds bmc.Credentials, publisher provisioner.EventPublisher) (*ironicProvisioner, error) {
+	log.Info("ironic settings",
+		"endpoint", ironicEndpoint,
+		"deployKernelURL", deployKernelURL,
+		"deployRamdiskURL", deployRamdiskURL,
+	)
 	client, err := noauth.NewBareMetalNoAuth(noauth.EndpointOpts{
 		IronicEndpoint: ironicEndpoint,
 	})


### PR DESCRIPTION
Apparently make passes the quotes through as part of the value of the
variable, which then causes problems when we try to use the URLs. So,
remove the quotes.

Also adds 1 log call to show which values are going to be used when
the ironic provisioner is created.